### PR TITLE
fix(daemon): adopt DaemonLogger instead of raw console calls

### DIFF
--- a/apps/daemon/src/http-server-factory.ts
+++ b/apps/daemon/src/http-server-factory.ts
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 import http from 'node:http';
+import { createLogger } from '@accomplish_ai/agent-core';
 import { RateLimiter } from './rate-limiter.js';
 
 const MAX_BODY_SIZE = 1024 * 1024; // 1 MB
@@ -72,6 +73,7 @@ export function createHttpServer(
   options: HttpServerOptions,
 ): Promise<{ server: http.Server; port: number }> {
   const { authToken, rateLimiter, routes, serviceName, port: requestedPort } = options;
+  const logger = createLogger(serviceName);
 
   return new Promise((resolve, reject) => {
     const server = http.createServer(async (req, res) => {
@@ -116,25 +118,25 @@ export function createHttpServer(
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Internal server error' }));
         }
-        console.error(`[${serviceName}] Unhandled error in ${route.method} ${route.path}:`, error);
+        logger.error(`Unhandled error in ${route.method} ${route.path}:`, error);
       }
     });
 
     server.listen(requestedPort ?? 0, '127.0.0.1', () => {
       const addr = server.address();
       const port = addr && typeof addr === 'object' ? addr.port : 0;
-      console.log(`[${serviceName}] Listening on port ${port}`);
+      logger.info(`Listening on port ${port}`);
       resolve({ server, port });
     });
 
     server.on('error', (error: NodeJS.ErrnoException) => {
       if (error.code === 'EADDRINUSE' && requestedPort) {
         // Port already in use — fall back to OS-assigned port
-        console.warn(`[${serviceName}] Port ${requestedPort} in use, falling back to random port`);
+        logger.warn(`Port ${requestedPort} in use, falling back to random port`);
         server.listen(0, '127.0.0.1', () => {
           const addr = server.address();
           const port = addr && typeof addr === 'object' ? addr.port : 0;
-          console.log(`[${serviceName}] Listening on fallback port ${port}`);
+          logger.info(`Listening on fallback port ${port}`);
           resolve({ server, port });
         });
       } else {

--- a/apps/daemon/src/index.ts
+++ b/apps/daemon/src/index.ts
@@ -8,6 +8,7 @@ import {
   getPidFilePath,
   acquirePidLock,
   installCrashHandlers,
+  logger,
   type PidLockHandle,
   PERMISSION_API_PORT,
   QUESTION_API_PORT,
@@ -56,15 +57,15 @@ async function main(): Promise<void> {
   }
 
   if (!dataDir && isDevMode) {
-    console.warn('[Daemon] Warning: running in dev mode without --data-dir, using ~/.accomplish');
+    logger.warn('Warning: running in dev mode without --data-dir, using ~/.accomplish');
   }
 
-  console.log(`[Daemon] Starting... (dataDir=${dataDir ?? '~/.accomplish (dev fallback)'})`);
+  logger.info(`Starting... (dataDir=${dataDir ?? '~/.accomplish (dev fallback)'})`);
 
   // 1. Acquire PID lock scoped to dataDir (atomic, with stale detection)
   const pidPath = getPidFilePath(dataDir);
   pidLock = acquirePidLock(pidPath);
-  console.log(`[Daemon] PID lock acquired: ${pidLock.pidPath} (pid=${process.pid})`);
+  logger.info(`PID lock acquired: ${pidLock.pidPath} (pid=${process.pid})`);
 
   // 2. Generate per-session auth token for HTTP APIs
   const authToken = crypto.randomUUID();
@@ -76,7 +77,7 @@ async function main(): Promise<void> {
   // 4. Crash recovery: mark stale running tasks as failed
   for (const task of storage.getTasks()) {
     if (task.status === 'running') {
-      console.warn(`[Daemon] Crash recovery: marking stale task ${task.id} as failed`);
+      logger.warn(`Crash recovery: marking stale task ${task.id} as failed`);
       storage.updateTaskStatus(task.id, 'failed', new Date().toISOString());
     }
   }
@@ -109,8 +110,8 @@ async function main(): Promise<void> {
   const socketPath = args.socketPath || getSocketPath(dataDir);
   const rpc = new DaemonRpcServer({
     socketPath,
-    onConnection: (clientId) => console.log(`[Daemon] Client connected: ${clientId}`),
-    onDisconnection: (clientId) => console.log(`[Daemon] Client disconnected: ${clientId}`),
+    onConnection: (clientId) => logger.info(`Client connected: ${clientId}`),
+    onDisconnection: (clientId) => logger.info(`Client disconnected: ${clientId}`),
   });
 
   // 7. Initialize permission service
@@ -166,9 +167,9 @@ async function main(): Promise<void> {
 
   // Start scheduler after RPC server is ready
   schedulerService.start();
-  console.log('[Daemon] Scheduler started');
+  logger.info('Scheduler started');
 
-  console.log(`[Daemon] Listening on ${socketPath}`);
+  logger.info(`Listening on ${socketPath}`);
 
   // 12. Graceful shutdown with drain phase
   let shuttingDown = false;
@@ -177,15 +178,15 @@ async function main(): Promise<void> {
       return;
     }
     shuttingDown = true;
-    console.log('[Daemon] Shutting down...');
+    logger.info('Shutting down...');
 
     // Stop scheduler FIRST — prevent new tasks from being launched during drain
     schedulerService.stop();
-    console.log('[Daemon] Scheduler stopped');
+    logger.info('Scheduler stopped');
 
     const activeCount = taskService.getActiveTaskCount();
     if (activeCount > 0) {
-      console.log(`[Daemon] Draining ${activeCount} active task(s)...`);
+      logger.info(`Draining ${activeCount} active task(s)...`);
       await new Promise<void>((resolve) => {
         let remaining = taskService.getActiveTaskCount();
         if (remaining === 0) {
@@ -194,7 +195,7 @@ async function main(): Promise<void> {
         }
 
         const drainTimeout = setTimeout(() => {
-          console.warn('[Daemon] Drain timeout reached, force-killing active tasks');
+          logger.warn('Drain timeout reached, force-killing active tasks');
           taskService.dispose();
           resolve();
         }, DRAIN_TIMEOUT_MS);
@@ -220,12 +221,12 @@ async function main(): Promise<void> {
     await rpc.stop();
     storageService.close();
     pidLock?.release();
-    console.log('[Daemon] Shutdown complete');
+    logger.info('Shutdown complete');
     process.exit(0);
   };
 
   const forceShutdown = () => {
-    console.error('[Daemon] Forced shutdown after timeout');
+    logger.error('Forced shutdown after timeout');
     pidLock?.release();
     process.exit(1);
   };
@@ -234,7 +235,7 @@ async function main(): Promise<void> {
   rpc.registerMethod(
     'daemon.shutdown',
     safeHandler(async () => {
-      console.log('[Daemon] Shutdown requested via RPC');
+      logger.info('Shutdown requested via RPC');
       // Defer actual shutdown to after the RPC response is sent
       setTimeout(() => void shutdown(), 100);
       return Promise.resolve();
@@ -252,7 +253,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error('[Daemon] Fatal error:', err);
+  logger.error('Fatal error:', err);
   pidLock?.release();
   process.exit(1);
 });

--- a/apps/daemon/src/scheduler-service.ts
+++ b/apps/daemon/src/scheduler-service.ts
@@ -6,7 +6,10 @@
  * and updates the database with last_run_at / next_run_at.
  */
 
+import { createLogger } from '@accomplish_ai/agent-core';
 import type { StorageAPI, ScheduledTask } from '@accomplish_ai/agent-core';
+
+const logger = createLogger('Scheduler');
 
 // =============================================================================
 // Cron Parsing & Matching
@@ -255,15 +258,15 @@ export class SchedulerService {
     for (const task of due) {
       const next = computeNextRunAt(task.cron, now);
       if (!next) {
-        console.warn(`[Scheduler] Could not compute next run for schedule ${task.id} — skipping`);
+        logger.warn(`Could not compute next run for schedule ${task.id} — skipping`);
         continue;
       }
       this.storage.updateScheduledTaskLastRun(task.id, nowIso, next);
-      console.log(`[Scheduler] Firing schedule ${task.id}: "${task.prompt.slice(0, 80)}"`);
+      logger.info(`Firing schedule ${task.id}: "${task.prompt.slice(0, 80)}"`);
       try {
         this.onTaskFire(task.prompt, task.workspaceId);
       } catch (err) {
-        console.error(`[Scheduler] Error firing task ${task.id}:`, err);
+        logger.error(`Error firing task ${task.id}:`, err);
       }
     }
   }
@@ -282,17 +285,15 @@ export class SchedulerService {
     for (const task of overdue) {
       const next = computeNextRunAt(task.cron, now);
       if (!next) {
-        console.warn(
-          `[Scheduler] Could not compute next run for overdue schedule ${task.id} — skipping`,
-        );
+        logger.warn(`Could not compute next run for overdue schedule ${task.id} — skipping`);
         continue;
       }
       this.storage.updateScheduledTaskLastRun(task.id, nowIso, next);
-      console.log(`[Scheduler] Catch-up firing schedule ${task.id}: "${task.prompt.slice(0, 80)}"`);
+      logger.info(`Catch-up firing schedule ${task.id}: "${task.prompt.slice(0, 80)}"`);
       try {
         this.onTaskFire(task.prompt, task.workspaceId);
       } catch (err) {
-        console.error(`[Scheduler] Error during catch-up for task ${task.id}:`, err);
+        logger.error(`Error during catch-up for task ${task.id}:`, err);
       }
     }
   }

--- a/apps/daemon/src/storage-service.ts
+++ b/apps/daemon/src/storage-service.ts
@@ -1,7 +1,9 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { mkdirSync } from 'node:fs';
-import { createStorage, type StorageAPI } from '@accomplish_ai/agent-core';
+import { createStorage, createLogger, type StorageAPI } from '@accomplish_ai/agent-core';
+
+const logger = createLogger('StorageService');
 
 const DEV_DEFAULT_DATA_DIR = join(homedir(), '.accomplish');
 
@@ -35,7 +37,7 @@ export class StorageService {
     });
 
     this.storage.initialize();
-    console.log(`[StorageService] Database initialized at ${databasePath}`);
+    logger.info(`Database initialized at ${databasePath}`);
     return this.storage;
   }
 
@@ -50,7 +52,7 @@ export class StorageService {
     if (this.storage) {
       this.storage.close();
       this.storage = null;
-      console.log('[StorageService] Database closed');
+      logger.info('Database closed');
     }
   }
 }

--- a/apps/daemon/src/websocket.ts
+++ b/apps/daemon/src/websocket.ts
@@ -1,4 +1,7 @@
 import { WebSocketServer, WebSocket } from 'ws';
+import { createLogger } from '@accomplish_ai/agent-core';
+
+const logger = createLogger('WebSocket');
 import type { Server } from 'http';
 
 export type DaemonEvent =
@@ -26,7 +29,7 @@ export function setupWebSocket(server: Server): WebSocketServer {
   wss = new WebSocketServer({ server, path: '/ws' });
 
   wss.on('connection', (ws) => {
-    console.log('[WebSocket] Client connected. Total:', wss!.clients.size);
+    logger.info(`Client connected. Total: ${wss?.clients.size ?? 0}`);
 
     ws.on('message', (raw) => {
       let msg: ClientMessage;
@@ -37,29 +40,29 @@ export function setupWebSocket(server: Server): WebSocketServer {
           parsed === null ||
           typeof (parsed as Record<string, unknown>).type !== 'string'
         ) {
-          console.warn('[WebSocket] Received message with invalid shape, ignoring');
+          logger.warn('Received message with invalid shape, ignoring');
           return;
         }
         msg = parsed as ClientMessage;
       } catch (err) {
-        console.warn('[WebSocket] Failed to parse incoming message:', err);
+        logger.warn('Failed to parse incoming message:', err);
         return;
       }
       messageHandlers.forEach((handler) => {
         try {
           handler(msg);
         } catch (err) {
-          console.error('[WebSocket] Handler error:', err);
+          logger.error('Handler error:', err);
         }
       });
     });
 
     ws.on('close', () => {
-      console.log('[WebSocket] Client disconnected. Total:', wss!.clients.size);
+      logger.info(`Client disconnected. Total: ${wss?.clients.size ?? 0}`);
     });
   });
 
-  console.log('[WebSocket] Server ready on /ws');
+  logger.info('Server ready on /ws');
   return wss;
 }
 

--- a/packages/agent-core/src/daemon/index.ts
+++ b/packages/agent-core/src/daemon/index.ts
@@ -33,4 +33,5 @@ export { acquirePidLock, PidLockError } from './pid-lock.js';
 export type { PidLockHandle, PidLockPayload } from './pid-lock.js';
 
 export { installCrashHandlers } from './crash-handlers.js';
-export { logger } from './logger.js';
+export { logger, createLogger } from './logger.js';
+export type { DaemonLogger } from './logger.js';

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -537,7 +537,8 @@ export { createSocketTransport } from './daemon/index.js';
 export type { SocketTransportOptions } from './daemon/index.js';
 export { acquirePidLock, PidLockError } from './daemon/index.js';
 export type { PidLockHandle, PidLockPayload } from './daemon/index.js';
-export { installCrashHandlers, logger } from './daemon/index.js';
+export { installCrashHandlers, logger, createLogger } from './daemon/index.js';
+export type { DaemonLogger } from './daemon/index.js';
 
 // Daemon protocol types (re-exported from common/types/daemon.ts)
 export { JSON_RPC_ERRORS } from './common/types/daemon.js';


### PR DESCRIPTION
## Summary

- `createLogger` / `DaemonLogger` were already implemented in `packages/agent-core/src/daemon/logger.ts` but never exported or used by any daemon service — 5 files (`index.ts`, `storage-service.ts`, `scheduler-service.ts`, `websocket.ts`, `http-server-factory.ts`) were all using raw `console.*` calls with manually-built `[Namespace]` prefixes
- Exports `createLogger` and `DaemonLogger` from agent-core's public API so daemon services can import without reaching into internal paths
- Replaces all 35 raw `console.*` calls across daemon services with the structured logger
- Fixes `wss!` non-null assertions in `websocket.ts` → `wss?.clients.size ?? 0`, consistent with the existing `getConnectedClientCount()` pattern

Two intentional `console.*` calls are preserved:
- `console.log(VERSION)` in `daemon/index.ts` — CLI `--version` flag output
- `console.error` for missing `--data-dir` — fires before any logger context is initialized

## Test plan

- [ ] `pnpm typecheck` passes (verified locally)
- [ ] `pnpm lint:eslint` passes on changed files (verified locally)
- [ ] `pnpm -F @accomplish/daemon test` passes
- [ ] `pnpm -F @accomplish_ai/agent-core test` passes
- [ ] Daemon starts and logs use `[Daemon]` / `[Scheduler]` / `[StorageService]` etc. prefixes as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced daemon logging infrastructure by transitioning from console output to structured logging throughout core daemon services, providing improved observability for operational monitoring and troubleshooting.

* **Chores**
  * Extended public API exports to include logger factory utilities and type definitions for structured logging support across daemon modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->