### PR TITLE
feat: add Homebrew cask formula for macOS install (#820)

### DIFF
--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,53 @@
+# Homebrew cask for Accomplish
+
+This directory contains a ready-to-use Homebrew cask formula for installing
+Accomplish on macOS.
+
+## For maintainers: publishing the tap
+
+Homebrew casks live in a separate tap repository, not in the main app repo.
+To enable `brew install --cask accomplish`:
+
+1. Create a new public repository named `accomplish-ai/homebrew-accomplish`
+   (the `homebrew-` prefix is required by Homebrew's tap convention).
+2. Copy `accomplish.rb` from this directory to `Casks/accomplish.rb` in that
+   new repo.
+3. (Optional) Add a workflow that bumps `version` and `sha256` on every
+   release — see the livecheck block in `accomplish.rb` and
+   [brew bump-cask-pr](https://docs.brew.sh/Manpage#bump-cask-pr)
+   for the automation pattern.
+4. Users can then run:
+
+   ```bash
+   brew tap accomplish-ai/accomplish
+   brew install --cask accomplish
+   ```
+
+Alternatively, the cask can be submitted to the central
+[homebrew-cask](https://github.com/Homebrew/homebrew-cask) repository so users
+get it without tapping. Note that homebrew-cask requires the app to be
+[notarized by Apple](https://docs.brew.sh/Acceptable-Casks#notarized); until
+Accomplish is notarized, a dedicated tap is the simpler path.
+
+## What the cask does
+
+- Downloads the correct DMG for the user's architecture (Apple Silicon or Intel).
+- Verifies SHA256 integrity.
+- Installs `Accomplish (formerly Openwork).app` into `/Applications`.
+- On uninstall (`brew uninstall --zap`), removes app support, logs,
+  preferences, and saved state directories.
+- Prints a caveat with the `xattr -c` workaround for the "damaged" error
+  caused by the unsigned bundle — this can be removed once the app is
+  notarized.
+
+## Verification performed
+
+- Tested cask syntax against `brew style --cask`.
+- SHA256 values computed locally against the current v0.3.8 release assets.
+- `app` stanza string matches the bundle name inside the mounted DMG
+  (`Accomplish (formerly Openwork).app`).
+- Bundle identifier `ai.accomplish.desktop` confirmed via
+  `/Applications/Accomplish (formerly Openwork).app/Contents/Info.plist`
+  and used in the `zap` stanza for a clean uninstall.
+
+Closes #820.

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -42,12 +42,20 @@ Accomplish is notarized, a dedicated tap is the simpler path.
 
 ## Verification performed
 
-- Tested cask syntax against `brew style --cask`.
+- Checked Ruby syntax with `ruby -c homebrew/accomplish.rb`. (Not run
+  through `brew style --cask` yet because the cask is not in a tap
+  repository; that check will run when the cask is submitted to a tap
+  or to `homebrew-cask`.)
 - SHA256 values computed locally against the current v0.3.8 release assets.
 - `app` stanza string matches the bundle name inside the mounted DMG
   (`Accomplish (formerly Openwork).app`).
 - Bundle identifier `ai.accomplish.desktop` confirmed via
   `/Applications/Accomplish (formerly Openwork).app/Contents/Info.plist`
   and used in the `zap` stanza for a clean uninstall.
+- `zap` paths cross-referenced against the Electron `userData` directory
+  (`APP_DATA_NAME = "Accomplish"` in `apps/desktop/src/main/index.ts`)
+  and the legacy-directory list in
+  `apps/desktop/src/main/store/legacyMigration.ts` so `brew uninstall --zap`
+  does not leave behind user data from the Openwork-era installs.
 
 Closes #820.

--- a/homebrew/accomplish.rb
+++ b/homebrew/accomplish.rb
@@ -29,8 +29,17 @@ cask "accomplish" do
   end
 
   zap trash: [
-    "~/Library/Application Support/ai.accomplish.desktop",
+    # Current userData (APP_DATA_NAME = "Accomplish" -> ~/Library/Application Support/Accomplish).
+    "~/Library/Application Support/Accomplish",
+    "~/Library/Application Support/accomplish",
+    # Legacy directories the migration layer still recognizes
+    # (apps/desktop/src/main/store/legacyMigration.ts).
+    "~/Library/Application Support/Openwork",
+    "~/Library/Application Support/openwork",
+    "~/Library/Application Support/@accomplish/desktop-v2",
     "~/Library/Application Support/Accomplish (formerly Openwork)",
+    # Bundle-id-based Electron state.
+    "~/Library/Logs/ai.accomplish.desktop",
     "~/Library/Logs/Accomplish (formerly Openwork)",
     "~/Library/Preferences/ai.accomplish.desktop.plist",
     "~/Library/Saved Application State/ai.accomplish.desktop.savedState",

--- a/homebrew/accomplish.rb
+++ b/homebrew/accomplish.rb
@@ -1,0 +1,38 @@
+cask "accomplish" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.3.8"
+  sha256 arm:   "3532dbc016e35a5a0037ce88506d8717987371dce9fcadd00e98982284c7e554",
+         intel: "420028c37b1cd78718be01ab83cde1a3d9704eb65be2416290696e634efe7ad3"
+
+  url "https://github.com/accomplish-ai/accomplish/releases/download/v#{version}/Accomplish-#{version}-mac-#{arch}.dmg",
+      verified: "github.com/accomplish-ai/accomplish/"
+  name "Accomplish"
+  desc "AI-powered desktop automation and productivity agent"
+  homepage "https://github.com/accomplish-ai/accomplish"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  app "Accomplish (formerly Openwork).app"
+
+  # The application is not notarized by Apple yet, so users may need to
+  # clear the quarantine attribute after install.
+  caveats do
+    <<~EOS
+      If you receive a "damaged" or "can't be opened" error, run:
+        sudo xattr -c '/Applications/Accomplish (formerly Openwork).app'
+    EOS
+  end
+
+  zap trash: [
+    "~/Library/Application Support/ai.accomplish.desktop",
+    "~/Library/Application Support/Accomplish (formerly Openwork)",
+    "~/Library/Logs/Accomplish (formerly Openwork)",
+    "~/Library/Preferences/ai.accomplish.desktop.plist",
+    "~/Library/Saved Application State/ai.accomplish.desktop.savedState",
+  ]
+end


### PR DESCRIPTION
Closes #820.

Per @TUARAN's note on the issue, a Homebrew cask must live in a separate tap repository, not in the main app repo. This PR stages a ready-to-publish cask under \`homebrew/\` so the content is ready the moment \`accomplish-ai/homebrew-accomplish\` is created — maintainers just copy \`homebrew/accomplish.rb\` into \`Casks/accomplish.rb\` in the new tap.

## What's in the PR

- \`homebrew/accomplish.rb\` — the cask formula.
- \`homebrew/README.md\` — a short publish guide for maintainers (tap setup, central \`homebrew-cask\` notes, and a livecheck/automation pointer).

## Cask details

- **Architecture-aware**: \`arm: "arm64"\`, \`intel: "x64"\`, pulling from the v0.3.8 DMG release assets.
- **SHA256 values**: computed locally against both current DMGs.
- **\`app\` stanza**: matches the actual bundle name inside the mounted DMG — \`Accomplish (formerly Openwork).app\`.
- **\`zap\` stanza**: cleans up app support, logs, prefs, and saved state under \`ai.accomplish.desktop\` (bundle identifier confirmed via \`Info.plist\`).
- **\`caveats\`**: includes the \`xattr -c\` workaround for the "damaged" error caused by the unsigned bundle. Can be dropped once the app is notarized.
- **\`livecheck\`** block set up so \`brew bump-cask-pr\` can auto-bump version + SHAs on every release.

## Verification

- Ruby syntax: \`ruby -c homebrew/accomplish.rb\` → \`Syntax OK\`.
- DMG SHA256s computed with \`shasum -a 256\` against both current release assets.
- Bundle name and identifier verified by mounting the arm64 DMG and reading \`Contents/Info.plist\`.
- \`brew style --cask\` intentionally skipped here — Homebrew requires casks to live inside a tap for style validation, which is the publish step maintainers will do next.

Happy to rename the folder, rewrite the README differently, or drop either file if you'd rather land just the cask. Let me know.

🤖 AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accomplish is now installable via Homebrew on macOS for Apple Silicon and Intel, pinned to the v0.3.8 release and auto-updatable via Homebrew checks.

* **Documentation**
  * Added a Homebrew setup guide with install/uninstall commands, notarization caveat, and an xattr workaround for macOS “damaged” errors.

* **Other**
  * Uninstall (“zap”) now removes app support, logs, preferences and legacy migration data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->