### PR TITLE
chore: remove www.accomplish.ai brand links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ Accomplish is an open source AI desktop agent that automates file management, do
   ·
   <a href="https://downloads.accomplish.ai/downloads/0.5.17/linux/Accomplish-0.5.17-linux-amd64.deb"><strong>Download for Linux (.deb x64)</strong></a>
   ·
-  <a href="https://www.accomplish.ai/">Accomplish website</a>
-  ·
-  <a href="https://www.accomplish.ai/blog/">Accomplish blog</a>
-  ·
   <a href="https://github.com/accomplish-ai/accomplish/releases">Accomplish releases</a>
 </p>
 
@@ -333,11 +329,11 @@ git push origin feature/amazing-feature
 
 <div align="center">
 
-**[Accomplish website](https://www.accomplish.ai/)** · **[Accomplish blog](https://www.accomplish.ai/blog/)** · **[Accomplish releases](https://github.com/accomplish-ai/accomplish/releases)** · **[Issues](https://github.com/accomplish-ai/accomplish/issues)** · **[Twitter](https://x.com/Accomplish_ai)**
+**[Accomplish releases](https://github.com/accomplish-ai/accomplish/releases)** · **[Issues](https://github.com/accomplish-ai/accomplish/issues)** · **[Twitter](https://x.com/Accomplish_ai)**
 
 <br />
 
-MIT License · Built by [Accomplish](https://www.accomplish.ai)
+MIT License
 
 <br />
 


### PR DESCRIPTION
## Jira

TBD — [Slack request from Guy](https://accomplish-ai.slack.com/archives/C0A86B8K8FM/p1778570585444879) (2026-05-12 10:23 IDT): _"Can someone pick a small task of removing the links from GitHub to accomplish.ai? We have them in the description and readme (and maybe elsewhere). It's important for reducing confusion and increase hygiene."_

## Summary

Removes 4 marketing/brand links to `www.accomplish.ai` from the public `accomplish` repo README. Functional `downloads.accomplish.ai` binary URLs are preserved.

## Why

Per Guy's request — hygiene + reduce confusion. The links to the marketing site (website, blog, "Built by Accomplish") no longer reflect where the project lives; the README's job is to point at the GitHub-hosted source + releases.

## What Changed

`README.md`:
- Removed `Accomplish website` and `Accomplish blog` from the **top download bar**.
- Removed `Accomplish website` and `Accomplish blog` from the **footer link row**.
- Removed `Built by [Accomplish](https://www.accomplish.ai)` trailing the MIT License line.
- **Preserved** the 12 functional `downloads.accomplish.ai/downloads/0.5.17/...` binary URLs and the `releases` / `Issues` / `Twitter` links.

Net diff: `1 file changed, 2 insertions(+), 6 deletions(-)`.

## Follow-up needed (repo-admin only — not in this PR)

The GitHub repo's **Homepage URL field** is currently set to `https://www.accomplish.ai`. That field is part of repo settings, not the codebase, so it requires a separate admin action:

```bash
gh api -X PATCH repos/accomplish-ai/accomplish -f homepage=''
```

Flagging here so it doesn't get missed.

## Open question for reviewer

If Guy meant to remove **all** accomplish.ai references (including `downloads.accomplish.ai/...` and `connectors.accomplish.ai`), say so — I'll open a follow-on PR with the broader cut. My read of "links from GitHub to accomplish.ai" was marketing-site links specifically, leaving functional/operational URLs in place.

## Validation

- `grep -nE "https?://(www\.)?accomplish\.ai" README.md` returns zero hits after the change.
- `grep -c "downloads.accomplish.ai" README.md` returns 13 (12 binary URLs + 1 in code-block context), confirming functional URLs preserved.
- README renders correctly locally (markdown lint clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified external links and references in documentation by consolidating to key resources (Accomplish releases, Issues, Twitter) and streamlined footer information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/accomplish-ai/accomplish/pull/980)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->