### PR TITLE
fix(daemon): reject non-object JSON request bodies

### DIFF
--- a/apps/daemon/__tests__/unit/http-server-factory.test.ts
+++ b/apps/daemon/__tests__/unit/http-server-factory.test.ts
@@ -141,6 +141,46 @@ describe('createHttpServer', () => {
     }
   });
 
+  it('should return 400 when the request body is not a JSON object', async () => {
+    const routeHandler = vi.fn(
+      async (
+        _data: Record<string, unknown>,
+        _req: http.IncomingMessage,
+        res: http.ServerResponse,
+      ) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      },
+    );
+    const rateLimiter = new RateLimiter(60_000, 10);
+    const { server, port } = await createHttpServer({
+      authToken: 'secret-token',
+      rateLimiter,
+      routes: [
+        {
+          method: 'POST',
+          path: '/ping',
+          handler: routeHandler,
+        },
+      ],
+      serviceName: 'HttpServerFactoryTest',
+    });
+
+    try {
+      const nullBody = await makeRequest(port, '/ping', 'POST', 'null', 'secret-token');
+      const arrayBody = await makeRequest(port, '/ping', 'POST', '[]', 'secret-token');
+
+      expect(nullBody.statusCode).toBe(400);
+      expect(JSON.parse(nullBody.body).error).toBe('Request body must be a JSON object');
+      expect(arrayBody.statusCode).toBe(400);
+      expect(JSON.parse(arrayBody.body).error).toBe('Request body must be a JSON object');
+      expect(routeHandler).not.toHaveBeenCalled();
+    } finally {
+      rateLimiter.dispose();
+      await closeServer(server);
+    }
+  });
+
   it('should return 204 for OPTIONS requests without auth', async () => {
     const rateLimiter = new RateLimiter(60_000, 10);
     const { server, port } = await createHttpServer({

--- a/apps/daemon/src/http-server-factory.ts
+++ b/apps/daemon/src/http-server-factory.ts
@@ -60,13 +60,22 @@ async function readBody(
 }
 
 function parseJsonBody(body: string, res: http.ServerResponse): Record<string, unknown> | null {
+  let data: unknown;
   try {
-    return JSON.parse(body);
+    data = JSON.parse(body);
   } catch {
     res.writeHead(400, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'Invalid JSON' }));
     return null;
   }
+
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Request body must be a JSON object' }));
+    return null;
+  }
+
+  return data as Record<string, unknown>;
 }
 
 export function createHttpServer(


### PR DESCRIPTION
## Summary
- Validate parsed daemon HTTP request bodies are non-null JSON objects
- Return `400` for `null` and array payloads instead of letting `null` requests hang before reaching the handler
- Add regression coverage for non-object payloads

## Verification
- `pnpm -F @accomplish/daemon test:unit -- http-server-factory`
- `pnpm -F @accomplish/daemon typecheck`
- `pnpm exec prettier --check apps/daemon/src/http-server-factory.ts apps/daemon/__tests__/unit/http-server-factory.test.ts`
- `pnpm lint:eslint` (passes with existing upstream warnings in `apps/web/src/client/pages/execution/useExecutionEffects.ts`, addressed separately in #981)
- `pnpm format:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request body validation to strictly require JSON objects, rejecting null values and arrays with appropriate error handling.

* **Tests**
  * Added unit tests verifying proper validation and error responses for invalid JSON request body formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/accomplish-ai/accomplish/pull/982)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->