### PR TITLE
fix(web): tolerate unavailable language storage

### DIFF
--- a/apps/web/__tests__/unit/renderer/i18n.storage.unit.test.ts
+++ b/apps/web/__tests__/unit/renderer/i18n.storage.unit.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import i18n from 'i18next';
+import { changeLanguage, getLanguagePreference } from '@/i18n';
+
+const originalLocalStorage = window.localStorage;
+
+function setThrowingLocalStorage(): void {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: vi.fn(() => {
+        throw new Error('storage unavailable');
+      }),
+      setItem: vi.fn(() => {
+        throw new Error('storage unavailable');
+      }),
+    },
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: originalLocalStorage,
+  });
+  vi.restoreAllMocks();
+});
+
+describe('i18n storage handling', () => {
+  it('falls back to auto when localStorage cannot be read', () => {
+    setThrowingLocalStorage();
+
+    expect(getLanguagePreference()).toBe('auto');
+  });
+
+  it('changes language when localStorage cannot be written', async () => {
+    setThrowingLocalStorage();
+    const changeLanguageSpy = vi.spyOn(i18n, 'changeLanguage').mockResolvedValue(i18n);
+
+    await changeLanguage('fr');
+
+    expect(changeLanguageSpy).toHaveBeenCalledWith('fr');
+  });
+});

--- a/apps/web/src/client/i18n/index.ts
+++ b/apps/web/src/client/i18n/index.ts
@@ -74,6 +74,22 @@ export const LANGUAGE_STORAGE_KEY = 'openwork-language';
 let isInitialized = false;
 let initializationPromise: Promise<void> | null = null;
 
+function getStoredLanguagePreference(): string | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setStoredLanguagePreference(language: string): void {
+  try {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+  } catch {
+    // localStorage may be unavailable in sandboxed/private contexts.
+  }
+}
+
 function updateDocumentDirection(language: string): void {
   if (typeof document === 'undefined') {
     return;
@@ -86,10 +102,7 @@ function updateDocumentDirection(language: string): void {
  * Returns the concrete language to use (resolves 'auto' via navigator).
  */
 function resolveStoredLanguage(): SupportedLanguage {
-  if (typeof localStorage === 'undefined') {
-    return 'en';
-  }
-  const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  const stored = getStoredLanguagePreference();
   if (stored === 'en' || stored === 'zh-CN' || stored === 'ru' || stored === 'fr') {
     return stored;
   }
@@ -209,7 +222,7 @@ export async function changeLanguage(
   language: 'en' | 'zh-CN' | 'ru' | 'fr' | 'auto',
 ): Promise<void> {
   const resolvedLanguage = language === 'auto' ? resolveAutoLanguage() : language;
-  localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+  setStoredLanguagePreference(language);
   await i18n.changeLanguage(resolvedLanguage);
   updateDocumentDirection(resolvedLanguage);
   // Persist to main process so the agent reads the correct language
@@ -224,10 +237,7 @@ export async function changeLanguage(
  * Get the current language preference from localStorage
  */
 export function getLanguagePreference(): 'en' | 'zh-CN' | 'ru' | 'fr' | 'auto' {
-  if (typeof localStorage === 'undefined') {
-    return 'auto';
-  }
-  const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  const stored = getStoredLanguagePreference();
   if (
     stored === 'en' ||
     stored === 'zh-CN' ||


### PR DESCRIPTION
## Summary
- Wrap language preference localStorage reads and writes so private/sandboxed storage failures do not break i18n
- Keep language changes working even when persistence is unavailable
- Add unit coverage for throwing localStorage get/set behavior

## Verification
- `pnpm -F @accomplish/web test:unit -- i18n.storage`
- `pnpm -F @accomplish/web typecheck`
- `pnpm exec prettier --check apps/web/src/client/i18n/index.ts apps/web/__tests__/unit/renderer/i18n.storage.unit.test.ts`
- `pnpm exec eslint apps/web/src/client/i18n/index.ts apps/web/__tests__/unit/renderer/i18n.storage.unit.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit tests for i18n storage to verify language preferences work correctly under various storage conditions.

* **Bug Fixes**
  * Improved language preference handling to gracefully manage scenarios where local storage is unavailable or restricted, ensuring consistent behavior across different environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/accomplish-ai/accomplish/pull/983)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->