### PR TITLE
feat(lmstudio): support optional bearer token for authenticated servers

### DIFF
--- a/apps/desktop/src/main/ipc/handlers/provider-config-handlers/lmstudio-handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers/provider-config-handlers/lmstudio-handlers.ts
@@ -9,19 +9,24 @@ import {
 import type { LMStudioConfig } from '@accomplish_ai/agent-core/desktop-main';
 import type { IpcHandler } from '../../types';
 import { getDaemonClient } from '../../../daemon-bootstrap';
+import { getApiKey } from '../../../store/secureStorage';
 
 // Milestone 5: LM Studio config reads/writes route through the daemon.
 export function registerLMStudioHandlers(handle: IpcHandler): void {
-  handle('lmstudio:test-connection', async (_event: IpcMainInvokeEvent, url: string) => {
-    return testLMStudioConnection({ url });
-  });
+  handle(
+    'lmstudio:test-connection',
+    async (_event: IpcMainInvokeEvent, url: string, apiKey?: string) => {
+      return testLMStudioConnection({ url, apiKey });
+    },
+  );
 
   handle('lmstudio:fetch-models', async (_event: IpcMainInvokeEvent) => {
     const config = await getDaemonClient().call('settings.getLMStudioConfig');
+    const apiKey = await getApiKey('lmstudio');
     if (!config || !config.baseUrl) {
       return { success: false, error: 'No LM Studio configured' };
     }
-    return fetchLMStudioModels({ baseUrl: config.baseUrl });
+    return fetchLMStudioModels({ baseUrl: config.baseUrl, apiKey: apiKey || undefined });
   });
 
   handle('lmstudio:get-config', async (_event: IpcMainInvokeEvent) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -298,6 +298,7 @@ const accomplishAPI = {
   // LM Studio configuration
   testLMStudioConnection: (
     url: string,
+    apiKey?: string,
   ): Promise<{
     success: boolean;
     models?: Array<{
@@ -306,7 +307,7 @@ const accomplishAPI = {
       toolSupport: 'supported' | 'unsupported' | 'unknown';
     }>;
     error?: string;
-  }> => ipcRenderer.invoke('lmstudio:test-connection', url),
+  }> => ipcRenderer.invoke('lmstudio:test-connection', url, apiKey),
 
   fetchLMStudioModels: (): Promise<{
     success: boolean;

--- a/apps/web/__tests__/unit/renderer/i18n.storage.unit.test.ts
+++ b/apps/web/__tests__/unit/renderer/i18n.storage.unit.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import i18n from 'i18next';
+import { changeLanguage, getLanguagePreference } from '@/i18n';
+
+const originalLocalStorage = window.localStorage;
+
+function setThrowingLocalStorage(): void {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: vi.fn(() => {
+        throw new Error('storage unavailable');
+      }),
+      setItem: vi.fn(() => {
+        throw new Error('storage unavailable');
+      }),
+    },
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: originalLocalStorage,
+  });
+  vi.restoreAllMocks();
+});
+
+describe('i18n storage handling', () => {
+  it('falls back to auto when localStorage cannot be read', () => {
+    setThrowingLocalStorage();
+
+    expect(getLanguagePreference()).toBe('auto');
+  });
+
+  it('changes language when localStorage cannot be written', async () => {
+    setThrowingLocalStorage();
+    const changeLanguageSpy = vi.spyOn(i18n, 'changeLanguage').mockResolvedValue(i18n);
+
+    await changeLanguage('fr');
+
+    expect(changeLanguageSpy).toHaveBeenCalledWith('fr');
+  });
+});

--- a/apps/web/locales/en/settings.json
+++ b/apps/web/locales/en/settings.json
@@ -141,6 +141,9 @@
   "lmstudio": {
     "serverUrl": "LM Studio Server URL",
     "serverHint": "Start LM Studio and enable the local server in Developer settings",
+    "apiKey": "Bearer Token (Optional)",
+    "apiKeyPlaceholder": "Enter LM Studio bearer token",
+    "apiKeyHint": "Required only if your LM Studio server has authentication enabled",
     "refreshModels": "Refresh model list"
   },
   "vertex": {

--- a/apps/web/locales/fr/settings.json
+++ b/apps/web/locales/fr/settings.json
@@ -141,6 +141,9 @@
   "lmstudio": {
     "serverUrl": "URL du serveur LM Studio",
     "serverHint": "Démarrez LM Studio et activez le serveur local dans les paramètres Développeur",
+    "apiKey": "Jeton Bearer (optionnel)",
+    "apiKeyPlaceholder": "Entrez le jeton bearer LM Studio",
+    "apiKeyHint": "Requis uniquement si l'authentification est activée sur le serveur LM Studio",
     "refreshModels": "Actualiser la liste des modèles"
   },
   "vertex": {

--- a/apps/web/locales/ru/settings.json
+++ b/apps/web/locales/ru/settings.json
@@ -141,6 +141,9 @@
   "lmstudio": {
     "serverUrl": "URL сервера LM Studio",
     "serverHint": "Запустите LM Studio и включите локальный сервер в настройках разработчика",
+    "apiKey": "Bearer токен (необязательно)",
+    "apiKeyPlaceholder": "Введите bearer токен LM Studio",
+    "apiKeyHint": "Нужен только если на сервере LM Studio включена аутентификация",
     "refreshModels": "Обновить список моделей"
   },
   "vertex": {

--- a/apps/web/locales/zh-CN/settings.json
+++ b/apps/web/locales/zh-CN/settings.json
@@ -141,6 +141,9 @@
   "lmstudio": {
     "serverUrl": "LM Studio 服务器地址",
     "serverHint": "启动 LM Studio 并在开发者设置中启用本地服务器",
+    "apiKey": "Bearer Token（可选）",
+    "apiKeyPlaceholder": "输入 LM Studio Bearer Token",
+    "apiKeyHint": "仅在 LM Studio 服务器启用鉴权时需要",
     "refreshModels": "刷新模型列表"
   },
   "vertex": {

--- a/apps/web/src/client/components/settings/providers/LMStudioProviderForm.tsx
+++ b/apps/web/src/client/components/settings/providers/LMStudioProviderForm.tsx
@@ -29,6 +29,8 @@ export function LMStudioProviderForm({
   const {
     serverUrl,
     setServerUrl,
+    apiKey,
+    setApiKey,
     connecting,
     refreshing,
     error,
@@ -70,6 +72,20 @@ export function LMStudioProviderForm({
                   className="w-full rounded-md border border-input bg-background px-3 py-2.5 text-sm"
                 />
                 <p className="mt-1 text-xs text-muted-foreground">{t('lmstudio.serverHint')}</p>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium text-foreground">
+                  {t('lmstudio.apiKey')}
+                </label>
+                <input
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder={t('lmstudio.apiKeyPlaceholder')}
+                  data-testid="lmstudio-api-key"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2.5 text-sm"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">{t('lmstudio.apiKeyHint')}</p>
               </div>
               <FormError error={error} />
               <ConnectButton onClick={handleConnect} connecting={connecting} />

--- a/apps/web/src/client/components/settings/providers/useLMStudioProviderConnect.ts
+++ b/apps/web/src/client/components/settings/providers/useLMStudioProviderConnect.ts
@@ -23,6 +23,8 @@ interface UseLMStudioProviderConnectOptions {
 export interface UseLMStudioProviderConnectReturn {
   serverUrl: string;
   setServerUrl: (url: string) => void;
+  apiKey: string;
+  setApiKey: (key: string) => void;
   connecting: boolean;
   refreshing: boolean;
   error: string | null;
@@ -38,6 +40,7 @@ export function useLMStudioProviderConnect({
 }: UseLMStudioProviderConnectOptions): UseLMStudioProviderConnectReturn {
   const { t } = useTranslation('settings');
   const [serverUrl, setServerUrl] = useState('http://localhost:1234');
+  const [apiKey, setApiKey] = useState('');
   const [connecting, setConnecting] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -56,12 +59,19 @@ export function useLMStudioProviderConnect({
 
     try {
       const accomplish = getAccomplish();
-      const result = await accomplish.testLMStudioConnection(serverUrl);
+      const trimmedKey = apiKey.trim() || undefined;
+      const result = await accomplish.testLMStudioConnection(serverUrl, trimmedKey);
 
       if (!result.success) {
         setError(result.error || t('status.connectionFailed'));
         setConnecting(false);
         return;
+      }
+
+      if (trimmedKey) {
+        await accomplish.addApiKey('lmstudio', trimmedKey);
+      } else {
+        await accomplish.removeApiKey('lmstudio');
       }
 
       const models = (result.models || []) as LMStudioModel[];
@@ -74,6 +84,8 @@ export function useLMStudioProviderConnect({
         credentials: {
           type: 'lmstudio',
           serverUrl,
+          hasApiKey: !!trimmedKey,
+          keyPrefix: trimmedKey ? trimmedKey.substring(0, 10) + '...' : undefined,
         } as LMStudioCredentials,
         lastConnectedAt: new Date().toISOString(),
         availableModels: models.map((m) => ({
@@ -84,6 +96,7 @@ export function useLMStudioProviderConnect({
       };
 
       onConnect(provider);
+      setApiKey('');
     } catch (err) {
       setError(err instanceof Error ? err.message : t('status.connectionFailed'));
     } finally {
@@ -102,9 +115,7 @@ export function useLMStudioProviderConnect({
 
     try {
       const accomplish = getAccomplish();
-      const currentUrl =
-        (baseProvider.credentials as LMStudioCredentials)?.serverUrl || 'http://localhost:1234';
-      const result = await accomplish.testLMStudioConnection(currentUrl);
+      const result = await accomplish.fetchLMStudioModels();
 
       if (!result.success) {
         setError(result.error || t('status.connectionFailed'));
@@ -160,6 +171,8 @@ export function useLMStudioProviderConnect({
   return {
     serverUrl,
     setServerUrl,
+    apiKey,
+    setApiKey,
     connecting,
     refreshing,
     error,

--- a/apps/web/src/client/i18n/index.ts
+++ b/apps/web/src/client/i18n/index.ts
@@ -74,6 +74,22 @@ export const LANGUAGE_STORAGE_KEY = 'openwork-language';
 let isInitialized = false;
 let initializationPromise: Promise<void> | null = null;
 
+function getStoredLanguagePreference(): string | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setStoredLanguagePreference(language: string): void {
+  try {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+  } catch {
+    // localStorage may be unavailable in sandboxed/private contexts.
+  }
+}
+
 function updateDocumentDirection(language: string): void {
   if (typeof document === 'undefined') {
     return;
@@ -86,10 +102,7 @@ function updateDocumentDirection(language: string): void {
  * Returns the concrete language to use (resolves 'auto' via navigator).
  */
 function resolveStoredLanguage(): SupportedLanguage {
-  if (typeof localStorage === 'undefined') {
-    return 'en';
-  }
-  const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  const stored = getStoredLanguagePreference();
   if (stored === 'en' || stored === 'zh-CN' || stored === 'ru' || stored === 'fr') {
     return stored;
   }
@@ -209,7 +222,7 @@ export async function changeLanguage(
   language: 'en' | 'zh-CN' | 'ru' | 'fr' | 'auto',
 ): Promise<void> {
   const resolvedLanguage = language === 'auto' ? resolveAutoLanguage() : language;
-  localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+  setStoredLanguagePreference(language);
   await i18n.changeLanguage(resolvedLanguage);
   updateDocumentDirection(resolvedLanguage);
   // Persist to main process so the agent reads the correct language
@@ -224,10 +237,7 @@ export async function changeLanguage(
  * Get the current language preference from localStorage
  */
 export function getLanguagePreference(): 'en' | 'zh-CN' | 'ru' | 'fr' | 'auto' {
-  if (typeof localStorage === 'undefined') {
-    return 'auto';
-  }
-  const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  const stored = getStoredLanguagePreference();
   if (
     stored === 'en' ||
     stored === 'zh-CN' ||

--- a/apps/web/src/client/lib/accomplish.ts
+++ b/apps/web/src/client/lib/accomplish.ts
@@ -328,7 +328,10 @@ interface AccomplishAPI {
   ): Promise<void>;
 
   // LM Studio configuration
-  testLMStudioConnection(url: string): Promise<{
+  testLMStudioConnection(
+    url: string,
+    apiKey?: string,
+  ): Promise<{
     success: boolean;
     models?: Array<{ id: string; name: string; toolSupport: ToolSupportStatus }>;
     error?: string;

--- a/packages/agent-core/src/common/types/providerSettings.ts
+++ b/packages/agent-core/src/common/types/providerSettings.ts
@@ -271,6 +271,8 @@ export interface ZaiCredentials {
 export interface LMStudioCredentials {
   type: 'lmstudio';
   serverUrl: string;
+  hasApiKey?: boolean;
+  keyPrefix?: string;
 }
 
 export interface HuggingFaceLocalCredentials {

--- a/packages/agent-core/src/opencode/config-providers-local.ts
+++ b/packages/agent-core/src/opencode/config-providers-local.ts
@@ -69,7 +69,7 @@ export async function buildOllamaConfig(ctx: ProviderBuildContext): Promise<Prov
 }
 
 export async function buildLMStudioConfig(ctx: ProviderBuildContext): Promise<ProviderBuildResult> {
-  const { providerSettings } = ctx;
+  const { providerSettings, getApiKey } = ctx;
   const lmstudioProvider = providerSettings.connectedProviders.lmstudio;
   if (
     lmstudioProvider?.connectionStatus === 'connected' &&
@@ -84,13 +84,17 @@ export async function buildLMStudioConfig(ctx: ProviderBuildContext): Promise<Pr
     log.info(
       `[OpenCode Config Builder] LM Studio configured: ${modelId} (tools: ${supportsTools})`,
     );
+    const lmstudioApiKey = getApiKey('lmstudio');
     return {
       configs: [
         {
           id: 'lmstudio',
           npm: '@ai-sdk/openai-compatible',
           name: 'LM Studio',
-          options: { baseURL: `${lmstudioProvider.credentials.serverUrl}/v1` },
+          options: {
+            baseURL: `${lmstudioProvider.credentials.serverUrl}/v1`,
+            ...(lmstudioApiKey ? { apiKey: lmstudioApiKey } : {}),
+          },
           models: { [modelId]: { name: modelId, tools: supportsTools } },
         },
       ],

--- a/packages/agent-core/src/providers/lmstudio-models.ts
+++ b/packages/agent-core/src/providers/lmstudio-models.ts
@@ -41,6 +41,8 @@ export interface LMStudioConnectionResult {
 export interface LMStudioFetchModelsOptions {
   /** The LM Studio server base URL */
   baseUrl: string;
+  /** Optional bearer API key for authenticated LM Studio servers */
+  apiKey?: string;
   /** Request timeout in milliseconds (default: 15000) */
   timeoutMs?: number;
 }
@@ -60,8 +62,18 @@ export function formatModelDisplayName(modelId: string): string {
 export async function fetchAndEnrichModels(
   baseUrl: string,
   timeoutMs: number,
+  apiKey?: string,
 ): Promise<LMStudioConnectionResult> {
-  const response = await fetchWithTimeout(`${baseUrl}/v1/models`, { method: 'GET' }, timeoutMs);
+  const headers: Record<string, string> = {};
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  const response = await fetchWithTimeout(
+    `${baseUrl}/v1/models`,
+    { method: 'GET', headers },
+    timeoutMs,
+  );
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));
@@ -78,7 +90,7 @@ export async function fetchAndEnrichModels(
 
   for (const m of rawModels) {
     const displayName = formatModelDisplayName(m.id);
-    const toolSupport = await testLMStudioModelToolSupport(baseUrl, m.id);
+    const toolSupport = await testLMStudioModelToolSupport(baseUrl, m.id, apiKey);
 
     models.push({
       id: m.id,
@@ -103,10 +115,10 @@ export async function fetchAndEnrichModels(
 export async function fetchLMStudioModels(
   options: LMStudioFetchModelsOptions,
 ): Promise<LMStudioConnectionResult> {
-  const { baseUrl, timeoutMs = LMSTUDIO_REQUEST_TIMEOUT_MS } = options;
+  const { baseUrl, apiKey, timeoutMs = LMSTUDIO_REQUEST_TIMEOUT_MS } = options;
 
   try {
-    return await fetchAndEnrichModels(baseUrl, timeoutMs);
+    return await fetchAndEnrichModels(baseUrl, timeoutMs, apiKey);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to fetch models';
     log.warn(`[LM Studio] Fetch failed: ${message}`);

--- a/packages/agent-core/src/providers/lmstudio.ts
+++ b/packages/agent-core/src/providers/lmstudio.ts
@@ -19,6 +19,8 @@ const log = createConsoleLogger({ prefix: 'LMStudio' });
 export interface LMStudioConnectionOptions {
   /** The LM Studio server URL */
   url: string;
+  /** Optional bearer API key for authenticated LM Studio servers */
+  apiKey?: string;
   /** Request timeout in milliseconds (default: 15000) */
   timeoutMs?: number;
 }
@@ -35,7 +37,7 @@ export interface LMStudioConnectionOptions {
 export async function testLMStudioConnection(
   options: LMStudioConnectionOptions,
 ): Promise<LMStudioConnectionResult> {
-  const { url, timeoutMs = LMSTUDIO_REQUEST_TIMEOUT_MS } = options;
+  const { url, apiKey, timeoutMs = LMSTUDIO_REQUEST_TIMEOUT_MS } = options;
 
   // Sanitize and validate URL
   const sanitizedUrl = sanitizeString(url, 'lmstudioUrl', 256);
@@ -50,7 +52,7 @@ export async function testLMStudioConnection(
   }
 
   try {
-    const result = await fetchAndEnrichModels(sanitizedUrl, timeoutMs);
+    const result = await fetchAndEnrichModels(sanitizedUrl, timeoutMs, apiKey);
 
     if (!result.success) {
       return result;

--- a/packages/agent-core/src/providers/tool-support-testing.ts
+++ b/packages/agent-core/src/providers/tool-support-testing.ts
@@ -16,6 +16,8 @@ export interface ToolSupportTestOptions {
   providerName: string;
   /** Request timeout in milliseconds (default: 10000) */
   timeoutMs?: number;
+  /** Optional bearer API key for authenticated OpenAI-compatible endpoints */
+  apiKey?: string;
 }
 
 /** Response type from OpenAI-compatible chat completions endpoint */
@@ -41,7 +43,7 @@ interface ChatCompletionResponse {
 export async function testModelToolSupport(
   options: ToolSupportTestOptions,
 ): Promise<ToolSupportStatus> {
-  const { baseUrl, modelId, providerName, timeoutMs = 10000 } = options;
+  const { baseUrl, modelId, providerName, timeoutMs = 10000, apiKey } = options;
 
   const testPayload = {
     model: modelId,
@@ -78,9 +80,14 @@ export async function testModelToolSupport(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (apiKey) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    }
+
     const response = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(testPayload),
       signal: controller.signal,
     });
@@ -191,10 +198,12 @@ export async function testOllamaModelToolSupport(
 export async function testLMStudioModelToolSupport(
   baseUrl: string,
   modelId: string,
+  apiKey?: string,
 ): Promise<ToolSupportStatus> {
   return testModelToolSupport({
     baseUrl,
     modelId,
     providerName: 'LM Studio',
+    apiKey,
   });
 }

--- a/packages/agent-core/tests/unit/providers/lmstudio-models.test.ts
+++ b/packages/agent-core/tests/unit/providers/lmstudio-models.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchAndEnrichModels } from '../../../src/providers/lmstudio-models.js';
+
+vi.mock('../../../src/utils/fetch.js', () => ({
+  fetchWithTimeout: vi.fn(),
+}));
+
+vi.mock('../../../src/providers/tool-support-testing.js', () => ({
+  testLMStudioModelToolSupport: vi.fn(),
+}));
+
+import { fetchWithTimeout } from '../../../src/utils/fetch.js';
+import { testLMStudioModelToolSupport } from '../../../src/providers/tool-support-testing.js';
+
+describe('fetchAndEnrichModels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends bearer auth header and forwards apiKey to tool support checks', async () => {
+    vi.mocked(fetchWithTimeout).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'llama-3.1', object: 'model' }],
+      }),
+    } as Response);
+    vi.mocked(testLMStudioModelToolSupport).mockResolvedValueOnce('supported');
+
+    const result = await fetchAndEnrichModels('http://localhost:1234', 15000, 'token-123');
+
+    expect(result.success).toBe(true);
+    expect(fetchWithTimeout).toHaveBeenCalledWith(
+      'http://localhost:1234/v1/models',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Authorization: 'Bearer token-123' },
+      }),
+      15000,
+    );
+    expect(testLMStudioModelToolSupport).toHaveBeenCalledWith(
+      'http://localhost:1234',
+      'llama-3.1',
+      'token-123',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds optional bearer-token support for LM Studio so users can connect to authenticated LM Studio servers without reverse-proxy workarounds.

## What changed

- Added optional LM Studio bearer token input in provider settings UI.
- Stored/cleared LM Studio token using existing secure API-key flow.
- Updated LM Studio connection test to accept an optional API key.
- Updated LM Studio model refresh path to read and use stored API key.
- Added Authorization header support for LM Studio `/v1/models` and tool-support probing.
- Included LM Studio API key in generated OpenAI-compatible runtime provider options when present.
- Extended LM Studio credentials typing with optional `hasApiKey` / `keyPrefix` metadata.
- Added locale strings (`en`, `fr`, `ru`, `zh-CN`) for the new LM Studio auth fields.
- Added a focused unit test for LM Studio auth propagation:
  - verifies bearer header for `/v1/models`
  - verifies API key forwarding to tool-support checks

## Validation

- `pnpm -F @accomplish_ai/agent-core exec vitest run tests/unit/providers/lmstudio-models.test.ts`
- `pnpm -F @accomplish/web typecheck`
- `pnpm -F @accomplish/desktop typecheck`
- Full pre-push checks also passed (typecheck, lint, format, build, unit tests).

## Related

- Addresses feature request: support bearer token for LM Studio connections.