### PR TITLE
feat(lmstudio): add optional Bearer Token authentication

### DIFF
--- a/apps/desktop/src/main/ipc/handlers/provider-config-handlers/lmstudio-handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers/provider-config-handlers/lmstudio-handlers.ts
@@ -13,16 +13,33 @@ import { getStorage } from '../../../store/storage';
 export function registerLMStudioHandlers(handle: IpcHandler): void {
   const storage = getStorage();
 
-  handle('lmstudio:test-connection', async (_event: IpcMainInvokeEvent, url: string) => {
-    return testLMStudioConnection({ url });
-  });
+  handle(
+    'lmstudio:test-connection',
+    async (_event: IpcMainInvokeEvent, url: string, apiKey?: string) => {
+      try {
+        const sanitizedUrl = sanitizeString(url, 'url', 256);
+        const resolvedApiKey =
+          apiKey !== undefined ? apiKey : storage.getApiKey('lmstudio') || undefined;
+        const sanitizedApiKey = resolvedApiKey
+          ? sanitizeString(resolvedApiKey, 'apiKey', 512)
+          : undefined;
+        return await testLMStudioConnection({ url: sanitizedUrl, apiKey: sanitizedApiKey });
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Connection test failed',
+        };
+      }
+    },
+  );
 
   handle('lmstudio:fetch-models', async (_event: IpcMainInvokeEvent) => {
     const config = storage.getLMStudioConfig();
     if (!config || !config.baseUrl) {
       return { success: false, error: 'No LM Studio configured' };
     }
-    return fetchLMStudioModels({ baseUrl: config.baseUrl });
+    const apiKey = storage.getApiKey('lmstudio') || undefined;
+    return fetchLMStudioModels({ baseUrl: config.baseUrl, apiKey });
   });
 
   handle('lmstudio:get-config', async (_event: IpcMainInvokeEvent) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -267,6 +267,7 @@ const accomplishAPI = {
   // LM Studio configuration
   testLMStudioConnection: (
     url: string,
+    apiKey?: string,
   ): Promise<{
     success: boolean;
     models?: Array<{
@@ -275,7 +276,7 @@ const accomplishAPI = {
       toolSupport: 'supported' | 'unsupported' | 'unknown';
     }>;
     error?: string;
-  }> => ipcRenderer.invoke('lmstudio:test-connection', url),
+  }> => ipcRenderer.invoke('lmstudio:test-connection', url, apiKey),
 
   fetchLMStudioModels: (): Promise<{
     success: boolean;

--- a/apps/web/locales/en/settings.json
+++ b/apps/web/locales/en/settings.json
@@ -1,5 +1,6 @@
 {
   "title": "Settings",
+  "clearApiKey": "Clear API Key",
   "setupTitle": "Set up Accomplish",
   "model": {
     "title": "Model",
@@ -123,7 +124,8 @@
   "lmstudio": {
     "serverUrl": "LM Studio Server URL",
     "serverHint": "Start LM Studio and enable the local server in Developer settings",
-    "refreshModels": "Refresh model list"
+    "refreshModels": "Refresh model list",
+    "bearerToken": "Bearer Token / API Key"
   },
   "vertex": {
     "serviceAccountTab": "Service Account",

--- a/apps/web/locales/fr/settings.json
+++ b/apps/web/locales/fr/settings.json
@@ -1,5 +1,6 @@
 {
   "title": "Paramètres",
+  "clearApiKey": "Effacer la clé API",
   "setupTitle": "Configurer Accomplish",
   "model": {
     "title": "Modèle",
@@ -123,7 +124,8 @@
   "lmstudio": {
     "serverUrl": "URL du serveur LM Studio",
     "serverHint": "Démarrez LM Studio et activez le serveur local dans les paramètres Développeur",
-    "refreshModels": "Actualiser la liste des modèles"
+    "refreshModels": "Actualiser la liste des modèles",
+    "bearerToken": "Jeton Bearer / Clé API"
   },
   "vertex": {
     "serviceAccountTab": "Compte de service",

--- a/apps/web/locales/ru/settings.json
+++ b/apps/web/locales/ru/settings.json
@@ -1,5 +1,6 @@
 {
   "title": "Настройки",
+  "clearApiKey": "Очистить API-ключ",
   "setupTitle": "Настройка Accomplish",
   "model": {
     "title": "Модель",
@@ -123,7 +124,8 @@
   "lmstudio": {
     "serverUrl": "URL сервера LM Studio",
     "serverHint": "Запустите LM Studio и включите локальный сервер в настройках разработчика",
-    "refreshModels": "Обновить список моделей"
+    "refreshModels": "Обновить список моделей",
+    "bearerToken": "Bearer-токен / API-ключ"
   },
   "vertex": {
     "serviceAccountTab": "Сервисный аккаунт",

--- a/apps/web/locales/zh-CN/settings.json
+++ b/apps/web/locales/zh-CN/settings.json
@@ -1,5 +1,6 @@
 {
   "title": "设置",
+  "clearApiKey": "清除 API 密钥",
   "setupTitle": "设置 Accomplish",
   "model": {
     "title": "模型",
@@ -123,7 +124,8 @@
   "lmstudio": {
     "serverUrl": "LM Studio 服务器地址",
     "serverHint": "启动 LM Studio 并在开发者设置中启用本地服务器",
-    "refreshModels": "刷新模型列表"
+    "refreshModels": "刷新模型列表",
+    "bearerToken": "Bearer 令牌 / API 密钥"
   },
   "vertex": {
     "serviceAccountTab": "服务账号",

--- a/apps/web/src/client/components/settings/providers/LMStudioProviderForm.tsx
+++ b/apps/web/src/client/components/settings/providers/LMStudioProviderForm.tsx
@@ -188,6 +188,7 @@ export function LMStudioProviderForm({
   const [connecting, setConnecting] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [apiKey, setApiKey] = useState('');
   const [availableModels, setAvailableModels] = useState<LMStudioModel[]>([]);
 
   const latestProviderRef = useRef(connectedProvider);
@@ -204,12 +205,19 @@ export function LMStudioProviderForm({
 
     try {
       const accomplish = getAccomplish();
-      const result = await accomplish.testLMStudioConnection(serverUrl);
+      const trimmedKey = apiKey.trim() || undefined;
+      const result = await accomplish.testLMStudioConnection(serverUrl, trimmedKey);
 
       if (!result.success) {
         setError(result.error || t('status.connectionFailed'));
         setConnecting(false);
         return;
+      }
+
+      if (trimmedKey) {
+        await accomplish.addApiKey('lmstudio', trimmedKey);
+      } else {
+        await accomplish.removeApiKey('lmstudio');
       }
 
       const models = (result.models || []) as LMStudioModel[];
@@ -222,6 +230,8 @@ export function LMStudioProviderForm({
         credentials: {
           type: 'lmstudio',
           serverUrl,
+          hasApiKey: !!trimmedKey,
+          keyPrefix: trimmedKey ? trimmedKey.substring(0, 10) + '...' : undefined,
         } as LMStudioCredentials,
         lastConnectedAt: new Date().toISOString(),
         availableModels: models.map((m) => ({
@@ -232,10 +242,23 @@ export function LMStudioProviderForm({
       };
 
       onConnect(provider);
+      setApiKey('');
     } catch (err) {
       setError(err instanceof Error ? err.message : t('status.connectionFailed'));
     } finally {
       setConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setApiKey('');
+    setError(null);
+    try {
+      const accomplish = getAccomplish();
+      await accomplish.removeApiKey('lmstudio');
+      onDisconnect();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('status.error'));
     }
   };
 
@@ -339,6 +362,40 @@ export function LMStudioProviderForm({
                 <p className="mt-1 text-xs text-muted-foreground">{t('lmstudio.serverHint')}</p>
               </div>
 
+              <div>
+                <label className="mb-2 block text-sm font-medium text-foreground">
+                  {t('lmstudio.bearerToken')}{' '}
+                  <span className="text-muted-foreground">({t('common.optional')})</span>
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    type="password"
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder={t('lmstudio.bearerToken')}
+                    data-testid="lmstudio-api-key"
+                    className="flex-1 rounded-md border border-input bg-background px-3 py-2.5 text-sm"
+                  />
+                  <button
+                    onClick={() => setApiKey('')}
+                    className="rounded-md border border-border p-2.5 text-muted-foreground hover:text-foreground transition-colors"
+                    type="button"
+                    disabled={!apiKey}
+                    aria-label={t('clearApiKey')}
+                    title={t('clearApiKey')}
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+
               <FormError error={error} />
               <ConnectButton onClick={handleConnect} connecting={connecting} />
             </motion.div>
@@ -352,22 +409,40 @@ export function LMStudioProviderForm({
               transition={settingsTransitions.enter}
               className="space-y-3"
             >
-              <div>
-                <label className="mb-2 block text-sm font-medium text-foreground">
-                  {t('lmstudio.serverUrl')}
-                </label>
-                <input
-                  type="text"
-                  value={
-                    (connectedProvider?.credentials as LMStudioCredentials)?.serverUrl ||
-                    'http://localhost:1234'
-                  }
-                  disabled
-                  className="w-full rounded-md border border-input bg-muted/50 px-3 py-2.5 text-sm text-muted-foreground"
-                />
+              <div className="space-y-3">
+                <div>
+                  <label className="mb-2 block text-sm font-medium text-foreground">
+                    {t('lmstudio.serverUrl')}
+                  </label>
+                  <input
+                    type="text"
+                    value={
+                      (connectedProvider?.credentials as LMStudioCredentials)?.serverUrl ||
+                      'http://localhost:1234'
+                    }
+                    disabled
+                    className="w-full rounded-md border border-input bg-muted/50 px-3 py-2.5 text-sm text-muted-foreground"
+                  />
+                </div>
+                {(connectedProvider?.credentials as LMStudioCredentials)?.hasApiKey && (
+                  <div>
+                    <label className="mb-2 block text-sm font-medium text-foreground">
+                      {t('lmstudio.bearerToken')}
+                    </label>
+                    <input
+                      type="text"
+                      value={
+                        (connectedProvider?.credentials as LMStudioCredentials)?.keyPrefix ||
+                        t('apiKey.saved')
+                      }
+                      disabled
+                      className="w-full rounded-md border border-input bg-muted/50 px-3 py-2.5 text-sm text-muted-foreground"
+                    />
+                  </div>
+                )}
               </div>
 
-              <ConnectedControls onDisconnect={onDisconnect} />
+              <ConnectedControls onDisconnect={handleDisconnect} />
 
               <div className="flex items-start gap-2">
                 <div className="flex-1 min-w-0">

--- a/apps/web/src/client/lib/accomplish.ts
+++ b/apps/web/src/client/lib/accomplish.ts
@@ -273,7 +273,10 @@ interface AccomplishAPI {
   ): Promise<void>;
 
   // LM Studio configuration
-  testLMStudioConnection(url: string): Promise<{
+  testLMStudioConnection(
+    url: string,
+    apiKey?: string,
+  ): Promise<{
     success: boolean;
     models?: Array<{ id: string; name: string; toolSupport: ToolSupportStatus }>;
     error?: string;

--- a/packages/agent-core/src/common/types/provider.ts
+++ b/packages/agent-core/src/common/types/provider.ts
@@ -205,6 +205,7 @@ export interface LMStudioModel {
 export interface LMStudioConfig {
   baseUrl: string;
   enabled: boolean;
+  apiKey?: string;
   lastValidated?: number;
   models?: LMStudioModel[];
 }

--- a/packages/agent-core/src/common/types/providerSettings.ts
+++ b/packages/agent-core/src/common/types/providerSettings.ts
@@ -238,6 +238,8 @@ export interface ZaiCredentials {
 export interface LMStudioCredentials {
   type: 'lmstudio';
   serverUrl: string;
+  hasApiKey?: boolean;
+  keyPrefix?: string;
 }
 
 export interface CustomCredentials {

--- a/packages/agent-core/src/opencode/config-builder.ts
+++ b/packages/agent-core/src/opencode/config-builder.ts
@@ -508,6 +508,7 @@ export async function buildProviderConfigs(
       name: 'LM Studio',
       options: {
         baseURL: `${lmstudioProvider.credentials.serverUrl}/v1`,
+        apiKey: getApiKey('lmstudio') || undefined,
       },
       models: {
         [modelId]: { name: modelId, tools: supportsTools },
@@ -528,7 +529,10 @@ export async function buildProviderConfigs(
         id: 'lmstudio',
         npm: '@ai-sdk/openai-compatible',
         name: 'LM Studio',
-        options: { baseURL: `${lmstudioConfig.baseUrl}/v1` },
+        options: {
+          baseURL: `${lmstudioConfig.baseUrl}/v1`,
+          apiKey: getApiKey('lmstudio') || undefined,
+        },
         models,
       });
       log.info(`[OpenCode Config Builder] LM Studio (legacy) configured: ${Object.keys(models)}`);

--- a/packages/agent-core/src/providers/lmstudio.ts
+++ b/packages/agent-core/src/providers/lmstudio.ts
@@ -40,6 +40,8 @@ export interface LMStudioConnectionOptions {
   url: string;
   /** Request timeout in milliseconds (default: 15000) */
   timeoutMs?: number;
+  /** Optional API Key or Bearer Token */
+  apiKey?: string;
 }
 
 /** Options for fetching LM Studio models */
@@ -48,6 +50,8 @@ export interface LMStudioFetchModelsOptions {
   baseUrl: string;
   /** Request timeout in milliseconds (default: 15000) */
   timeoutMs?: number;
+  /** Optional API Key or Bearer Token */
+  apiKey?: string;
 }
 
 /**
@@ -73,7 +77,7 @@ function formatModelDisplayName(modelId: string): string {
 export async function testLMStudioConnection(
   options: LMStudioConnectionOptions,
 ): Promise<LMStudioConnectionResult> {
-  const { url, timeoutMs = LMSTUDIO_REQUEST_TIMEOUT_MS } = options;
+  const { url, apiKey, timeoutMs = LMSTUDIO_REQUEST_TIMEOUT_MS } = options;
 
   // Sanitize and validate URL
   const sanitizedUrl = sanitizeString(url, 'lmstudioUrl', 256);
@@ -88,9 +92,14 @@ export async function testLMStudioConnection(
   }
 
   try {
+    const headers: Record<string, string> = {};
+    if (apiKey && apiKey.trim() !== '') {
+      headers['Authorization'] = `Bearer ${apiKey.trim()}`;
+    }
+
     const response = await fetchWithTimeout(
       `${sanitizedUrl}/v1/models`,
-      { method: 'GET' },
+      { method: 'GET', headers },
       timeoutMs,
     );
 
@@ -116,7 +125,7 @@ export async function testLMStudioConnection(
 
     for (const m of rawModels) {
       const displayName = formatModelDisplayName(m.id);
-      const toolSupport = await testLMStudioModelToolSupport(sanitizedUrl, m.id);
+      const toolSupport = await testLMStudioModelToolSupport(sanitizedUrl, m.id, apiKey);
 
       models.push({
         id: m.id,
@@ -155,10 +164,19 @@ export async function testLMStudioConnection(
 export async function fetchLMStudioModels(
   options: LMStudioFetchModelsOptions,
 ): Promise<LMStudioConnectionResult> {
-  const { baseUrl, timeoutMs = LMSTUDIO_REQUEST_TIMEOUT_MS } = options;
+  const { baseUrl, apiKey, timeoutMs = LMSTUDIO_REQUEST_TIMEOUT_MS } = options;
 
   try {
-    const response = await fetchWithTimeout(`${baseUrl}/v1/models`, { method: 'GET' }, timeoutMs);
+    const headers: Record<string, string> = {};
+    if (apiKey && apiKey.trim() !== '') {
+      headers['Authorization'] = `Bearer ${apiKey.trim()}`;
+    }
+
+    const response = await fetchWithTimeout(
+      `${baseUrl}/v1/models`,
+      { method: 'GET', headers },
+      timeoutMs,
+    );
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
@@ -175,7 +193,7 @@ export async function fetchLMStudioModels(
 
     for (const m of rawModels) {
       const displayName = formatModelDisplayName(m.id);
-      const toolSupport = await testLMStudioModelToolSupport(baseUrl, m.id);
+      const toolSupport = await testLMStudioModelToolSupport(baseUrl, m.id, apiKey);
 
       models.push({
         id: m.id,
@@ -214,6 +232,10 @@ export function validateLMStudioConfig(config: LMStudioConfig): void {
 
   if (config.lastValidated !== undefined && typeof config.lastValidated !== 'number') {
     throw new Error('Invalid LM Studio configuration');
+  }
+
+  if (config.apiKey !== undefined && typeof config.apiKey !== 'string') {
+    throw new Error('Invalid LM Studio configuration: apiKey must be a string');
   }
 
   if (config.models !== undefined) {

--- a/packages/agent-core/src/providers/tool-support-testing.ts
+++ b/packages/agent-core/src/providers/tool-support-testing.ts
@@ -16,6 +16,8 @@ export interface ToolSupportTestOptions {
   providerName: string;
   /** Request timeout in milliseconds (default: 10000) */
   timeoutMs?: number;
+  /** Optional API Key or Bearer Token */
+  apiKey?: string;
 }
 
 /** Response type from OpenAI-compatible chat completions endpoint */
@@ -41,7 +43,7 @@ interface ChatCompletionResponse {
 export async function testModelToolSupport(
   options: ToolSupportTestOptions,
 ): Promise<ToolSupportStatus> {
-  const { baseUrl, modelId, providerName, timeoutMs = 10000 } = options;
+  const { baseUrl, modelId, providerName, timeoutMs = 10000, apiKey } = options;
 
   const testPayload = {
     model: modelId,
@@ -78,9 +80,14 @@ export async function testModelToolSupport(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (apiKey && apiKey.trim() !== '') {
+      headers['Authorization'] = `Bearer ${apiKey.trim()}`;
+    }
+
     const response = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify(testPayload),
       signal: controller.signal,
     });
@@ -191,10 +198,12 @@ export async function testOllamaModelToolSupport(
 export async function testLMStudioModelToolSupport(
   baseUrl: string,
   modelId: string,
+  apiKey?: string,
 ): Promise<ToolSupportStatus> {
   return testModelToolSupport({
     baseUrl,
     modelId,
     providerName: 'LM Studio',
+    apiKey,
   });
 }


### PR DESCRIPTION
## Summary

Add optional API key / Bearer Token authentication support for the LM Studio provider, enabling secure communication with LM Studio servers configured behind reverse proxies or with authentication-enabled endpoints.

## Motivation

LM Studio servers deployed in production environments often sit behind reverse proxies (e.g., nginx, Caddy) that require `Authorization: Bearer <token>` headers. The current LM Studio integration has no way to pass credentials, making it impossible to connect to secured instances.

## Changes

### Core Types (`packages/agent-core`)
- Added optional `apiKey` field to `LMStudioConfig` interface
- Added `hasApiKey` and `keyPrefix` to `LMStudioCredentials` (mirroring the existing LiteLLM credential architecture)

### Connection & Tool Testing
- Updated `ToolSupportTestOptions` to accept an optional `apiKey`
- `testModelToolSupport` now conditionally injects the `Authorization: Bearer` header when an API key is provided
- `LMStudioConnectionOptions` and `LMStudioFetchModelsOptions` now accept an optional `apiKey`
- Connection test and model fetch requests inject the header when present

### Config Builder
- `config-builder.ts` now injects the stored LM Studio API key into `@ai-sdk/openai-compatible` provider configurations

### Desktop IPC & Preload
- Updated `lmstudio-handlers.ts` to accept, resolve, and sanitize API keys via secure storage
- Updated preload interface signature to pass API key through the IPC bridge

### Frontend
- Added Bearer Token input field to `LMStudioProviderForm.tsx` with password masking
- Credential state management follows the established `hasApiKey`/`keyPrefix` pattern used by LiteLLM
- Disconnect button properly resets the API key state

### Translations
- Added `bearerToken` localization key to `en`, `fr`, `ru`, `zh-CN` settings files

## Security Considerations

- API key is stored via the existing secure storage mechanism (same as LiteLLM keys)
- The `Authorization` header is **completely omitted** when `apiKey` is falsy or empty
- No raw API key values are logged to console or telemetry
- Frontend input uses password masking for the token field

## Testing

- **TypeScript typecheck**: All 4 workspace projects pass `pnpm run typecheck`
- **Unit tests**: 290/290 desktop tests pass (2 pre-existing Electron install failures unrelated to this change)
- **ESLint + Prettier**: All lint-staged checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional LM Studio API key / Bearer token when connecting, with a clear button and truncated saved-token display; connected UI shows read-only server URL and saved-token indicator.
  * Model refresh and connection testing use the provided or stored API key.

* **Bug Fixes**
  * Connection test now returns structured failure info instead of crashing on errors.

* **Documentation**
  * Localization updated (en, fr, ru, zh-CN) with API key labels and "Clear API Key".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/accomplish-ai/accomplish/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->