### PR TITLE
fix(connectors): support unauthenticated MCP servers

### DIFF
--- a/apps/daemon/__tests__/unit/task-config-builder.unit.test.ts
+++ b/apps/daemon/__tests__/unit/task-config-builder.unit.test.ts
@@ -343,6 +343,50 @@ describe('daemon onBeforeStart — integration against real resolveTaskConfig + 
     expect(connectorServer.headers?.Authorization).toBe('Bearer slack-access-token');
   });
 
+  it('includes connected MCP connectors that do not require authentication', async () => {
+    const storage = makeStorage({
+      getEnabledConnectors: vi.fn(() => [
+        {
+          id: 'conn-local-1',
+          name: 'local',
+          url: 'http://localhost:3333/mcp',
+          status: 'connected',
+        },
+      ]),
+      getConnectorTokens: vi.fn(() => null),
+      setConnectorStatus: vi.fn(),
+    });
+
+    const { configPath } = await onBeforeStart(
+      storage as never,
+      {
+        userDataPath: tmpUserData,
+        mcpToolsPath: fakeMcpToolsPath,
+        isPackaged: false,
+        resourcesPath: '',
+        appPath: '',
+      },
+      { taskId: 'tsk_no_auth_conn', workspaceId: undefined },
+    );
+
+    const written = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    const mcp = (written.mcp ?? written.mcpServers ?? {}) as Record<
+      string,
+      { type?: string; url?: string; headers?: Record<string, string> }
+    >;
+    const userConnectorEntries = Object.entries(mcp).filter(([key]) =>
+      key.startsWith('connector-'),
+    );
+
+    expect(userConnectorEntries).toHaveLength(1);
+    const [connectorKey, connectorServer] = userConnectorEntries[0];
+    expect(connectorKey).toBe('connector-local-conn-l');
+    expect(connectorServer.type).toBe('remote');
+    expect(connectorServer.url).toBe('http://localhost:3333/mcp');
+    expect(connectorServer.headers).toBeUndefined();
+    expect(storage.setConnectorStatus).not.toHaveBeenCalled();
+  });
+
   it('registers gws-mcp + gmail-mcp + calendar-mcp + GWS_ACCOUNTS_MANIFEST env when accounts are connected', async () => {
     const now = Date.now();
     gwsRows = [

--- a/apps/desktop/__tests__/unit/main/ipc/connector-handlers.unit.test.ts
+++ b/apps/desktop/__tests__/unit/main/ipc/connector-handlers.unit.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  class OAuthMetadataDiscoveryError extends Error {
+    constructor(
+      readonly metadataUrl: string,
+      readonly status: number,
+      readonly statusText: string,
+    ) {
+      super(`Failed to discover OAuth metadata from ${metadataUrl}: ${status} ${statusText}`);
+      this.name = 'OAuthMetadataDiscoveryError';
+    }
+  }
+
+  return {
+    handlers: new Map<string, (...args: unknown[]) => unknown>(),
+    shellOpenExternal: vi.fn(),
+    daemonClient: { call: vi.fn() },
+    discoverOAuthMetadata: vi.fn(),
+    registerOAuthClient: vi.fn(),
+    generatePkceChallenge: vi.fn(() => ({
+      codeVerifier: 'verifier',
+      codeChallenge: 'challenge',
+    })),
+    buildAuthorizationUrl: vi.fn(() => 'https://auth.example.com/authorize'),
+    exchangeCodeForTokens: vi.fn(),
+    OAuthMetadataDiscoveryError,
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      mocks.handlers.set(channel, handler);
+    }),
+  },
+  shell: {
+    openExternal: mocks.shellOpenExternal,
+  },
+  BrowserWindow: {
+    getFocusedWindow: vi.fn(() => null),
+    getAllWindows: vi.fn(() => []),
+  },
+}));
+
+vi.mock('@main/daemon-bootstrap', () => ({
+  getDaemonClient: vi.fn(() => mocks.daemonClient),
+}));
+
+vi.mock('@accomplish_ai/agent-core/desktop-main', () => ({
+  sanitizeString: (value: string) => value,
+  discoverOAuthMetadata: mocks.discoverOAuthMetadata,
+  registerOAuthClient: mocks.registerOAuthClient,
+  generatePkceChallenge: mocks.generatePkceChallenge,
+  buildAuthorizationUrl: mocks.buildAuthorizationUrl,
+  exchangeCodeForTokens: mocks.exchangeCodeForTokens,
+  OAuthMetadataDiscoveryError: mocks.OAuthMetadataDiscoveryError,
+}));
+
+const { registerConnectorHandlers } = await import('@main/ipc/handlers/connector-handlers');
+
+function getHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  const handler = mocks.handlers.get(channel);
+  if (!handler) {
+    throw new Error(`No handler registered for channel: ${channel}`);
+  }
+  return handler as (...args: unknown[]) => Promise<unknown>;
+}
+
+describe('connector IPC handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.handlers.clear();
+  });
+
+  it('connects a custom MCP connector without OAuth when metadata discovery returns 404', async () => {
+    const connector = {
+      id: 'conn-local-1',
+      name: 'Local MCP',
+      url: 'http://localhost:3333/mcp',
+      status: 'disconnected',
+      isEnabled: true,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    mocks.daemonClient.call.mockImplementation(async (method: string) => {
+      if (method === 'connectors.getById') {
+        return connector;
+      }
+      return undefined;
+    });
+    mocks.discoverOAuthMetadata.mockRejectedValue(
+      new mocks.OAuthMetadataDiscoveryError(
+        'http://localhost:3333/.well-known/oauth-authorization-server',
+        404,
+        'Not Found',
+      ),
+    );
+
+    registerConnectorHandlers();
+    const result = await getHandler('connectors:start-oauth')({}, connector.id);
+
+    expect(result).toEqual({
+      connector: expect.objectContaining({
+        id: connector.id,
+        status: 'connected',
+        lastConnectedAt: expect.any(String),
+      }),
+    });
+    expect(mocks.daemonClient.call).toHaveBeenCalledWith('connectors.deleteTokens', {
+      connectorId: connector.id,
+    });
+    expect(mocks.daemonClient.call).toHaveBeenCalledWith('connectors.upsert', {
+      connector: expect.objectContaining({
+        id: connector.id,
+        status: 'connected',
+      }),
+    });
+    expect(mocks.shellOpenExternal).not.toHaveBeenCalled();
+    expect(mocks.registerOAuthClient).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/ipc/handlers/connector-handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers/connector-handlers.ts
@@ -4,6 +4,7 @@ import type { IpcMainInvokeEvent } from 'electron';
 import {
   sanitizeString,
   discoverOAuthMetadata,
+  OAuthMetadataDiscoveryError,
   registerOAuthClient,
   generatePkceChallenge,
   buildAuthorizationUrl,
@@ -108,7 +109,31 @@ export function registerConnectorHandlers(): void {
       throw new Error('Connector not found');
     }
 
-    const metadata = await discoverOAuthMetadata(connector.url);
+    let metadata: OAuthMetadata;
+    try {
+      metadata = await discoverOAuthMetadata(connector.url);
+    } catch (err) {
+      if (err instanceof OAuthMetadataDiscoveryError && err.status === 404) {
+        const {
+          oauthMetadata: _oauthMetadata,
+          clientRegistration: _clientRegistration,
+          ...rest
+        } = connector;
+        const now = new Date().toISOString();
+        const connectedConnector: McpConnector = {
+          ...rest,
+          status: 'connected',
+          lastConnectedAt: now,
+          updatedAt: now,
+        };
+
+        await client.call('connectors.deleteTokens', { connectorId });
+        await client.call('connectors.upsert', { connector: connectedConnector });
+        return { connector: connectedConnector };
+      }
+
+      throw err;
+    }
 
     let clientReg = connector.clientRegistration;
     if (!clientReg) {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -681,7 +681,9 @@ const accomplishAPI = {
   deleteConnector: (id: string): Promise<void> => ipcRenderer.invoke('connectors:delete', id),
   setConnectorEnabled: (id: string, enabled: boolean): Promise<void> =>
     ipcRenderer.invoke('connectors:set-enabled', id, enabled),
-  startConnectorOAuth: (connectorId: string): Promise<{ state: string; authUrl: string }> =>
+  startConnectorOAuth: (
+    connectorId: string,
+  ): Promise<{ state: string; authUrl: string } | { connector: McpConnector }> =>
     ipcRenderer.invoke('connectors:start-oauth', connectorId),
   completeConnectorOAuth: (state: string, code: string): Promise<McpConnector> =>
     ipcRenderer.invoke('connectors:complete-oauth', state, code),

--- a/apps/web/src/client/components/settings/connectors/useConnectors.ts
+++ b/apps/web/src/client/components/settings/connectors/useConnectors.ts
@@ -105,7 +105,13 @@ export function useConnectors() {
 
     try {
       const accomplish = getAccomplish();
-      return await accomplish.startConnectorOAuth(connectorId);
+      const result = await accomplish.startConnectorOAuth(connectorId);
+      if (result && 'connector' in result) {
+        setConnectors((prev) =>
+          prev.map((c) => (c.id === result.connector.id ? result.connector : c)),
+        );
+      }
+      return result;
     } catch (err) {
       setConnectors((prev) =>
         prev.map((c) => (c.id === connectorId ? { ...c, status: 'error' as const } : c)),

--- a/apps/web/src/client/lib/accomplish.ts
+++ b/apps/web/src/client/lib/accomplish.ts
@@ -634,7 +634,9 @@ interface AccomplishAPI {
   addConnector(name: string, url: string): Promise<McpConnector>;
   deleteConnector(id: string): Promise<void>;
   setConnectorEnabled(id: string, enabled: boolean): Promise<void>;
-  startConnectorOAuth(connectorId: string): Promise<{ state: string; authUrl: string }>;
+  startConnectorOAuth(
+    connectorId: string,
+  ): Promise<{ state: string; authUrl: string } | { connector: McpConnector }>;
   completeConnectorOAuth(state: string, code: string): Promise<McpConnector>;
   disconnectConnector(connectorId: string): Promise<void>;
   onMcpAuthCallback?(callback: (url: string) => void): () => void;

--- a/packages/agent-core/src/connectors/mcp-oauth.ts
+++ b/packages/agent-core/src/connectors/mcp-oauth.ts
@@ -3,7 +3,11 @@ import type { OAuthMetadata, OAuthClientRegistration } from '../common/types/con
 import { fetchWithTimeout } from './oauth-metadata.js';
 
 export type { OAuthProtectedResourceMetadata } from './oauth-metadata.js';
-export { discoverOAuthMetadata, discoverOAuthProtectedResourceMetadata } from './oauth-metadata.js';
+export {
+  OAuthMetadataDiscoveryError,
+  discoverOAuthMetadata,
+  discoverOAuthProtectedResourceMetadata,
+} from './oauth-metadata.js';
 export { exchangeCodeForTokens, refreshAccessToken, isTokenExpired } from './oauth-tokens.js';
 
 /**

--- a/packages/agent-core/src/connectors/oauth-metadata.ts
+++ b/packages/agent-core/src/connectors/oauth-metadata.ts
@@ -2,6 +2,17 @@ import type { OAuthMetadata } from '../common/types/connector.js';
 
 const OAUTH_FETCH_TIMEOUT_MS = 30_000;
 
+export class OAuthMetadataDiscoveryError extends Error {
+  constructor(
+    readonly metadataUrl: string,
+    readonly status: number,
+    readonly statusText: string,
+  ) {
+    super(`Failed to discover OAuth metadata from ${metadataUrl}: ${status} ${statusText}`);
+    this.name = 'OAuthMetadataDiscoveryError';
+  }
+}
+
 export interface OAuthProtectedResourceMetadata {
   resource: string;
   authorizationServers?: string[];
@@ -36,9 +47,7 @@ export async function discoverOAuthMetadata(serverUrl: string): Promise<OAuthMet
   });
 
   if (!response.ok) {
-    throw new Error(
-      `Failed to discover OAuth metadata from ${url.toString()}: ${response.status} ${response.statusText}`,
-    );
+    throw new OAuthMetadataDiscoveryError(url.toString(), response.status, response.statusText);
   }
 
   const data = (await response.json()) as Record<string, unknown>;

--- a/packages/agent-core/src/desktop-main.ts
+++ b/packages/agent-core/src/desktop-main.ts
@@ -30,6 +30,7 @@ export { installCrashHandlers } from './daemon/crash-handlers.js';
 // MCP OAuth helpers (pure HTTP fetch + PKCE)
 // -----------------------------------------------------------------------------
 export {
+  OAuthMetadataDiscoveryError,
   discoverOAuthMetadata,
   discoverOAuthProtectedResourceMetadata,
   registerOAuthClient,

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -500,6 +500,7 @@ export type {
 
 // MCP OAuth
 export {
+  OAuthMetadataDiscoveryError,
   discoverOAuthMetadata,
   discoverOAuthProtectedResourceMetadata,
   registerOAuthClient,

--- a/packages/agent-core/src/opencode/config-generator-types.ts
+++ b/packages/agent-core/src/opencode/config-generator-types.ts
@@ -31,12 +31,12 @@ export interface ConfigGeneratorOptions {
   enabledProviders?: string[];
   /** Browser configuration. Defaults to { mode: 'builtin' } */
   browser?: import('./generator-mcp.js').BrowserConfig;
-  /** Connected MCP remote servers with OAuth access tokens */
+  /** Connected MCP remote servers, with an OAuth access token when required */
   connectors?: Array<{
     id: string;
     name: string;
     url: string;
-    accessToken: string;
+    accessToken?: string;
   }>;
   /**
    * Binding, `instruction`-type workspace knowledge notes. Rendered under a

--- a/packages/agent-core/src/opencode/generator-mcp.ts
+++ b/packages/agent-core/src/opencode/generator-mcp.ts
@@ -65,7 +65,7 @@ export interface BuildMcpServersOptions {
     id: string;
     name: string;
     url: string;
-    accessToken: string;
+    accessToken?: string;
   }>;
   /**
    * Path to GWS accounts manifest JSON. When set, gmail-mcp, calendar-mcp,
@@ -231,8 +231,10 @@ export function buildMcpServers(options: BuildMcpServersOptions): Record<string,
       mcpServers[key] = {
         type: 'remote',
         url: connector.url,
-        headers: { Authorization: `Bearer ${connector.accessToken}` },
         enabled: true,
+        ...(connector.accessToken
+          ? { headers: { Authorization: `Bearer ${connector.accessToken}` } }
+          : {}),
       };
     }
   }

--- a/packages/agent-core/src/opencode/resolve-task-config.ts
+++ b/packages/agent-core/src/opencode/resolve-task-config.ts
@@ -255,9 +255,9 @@ function injectOpenAiStoreFlag(
 async function resolveConnectors(
   storage: StorageAPI,
   log: (level: 'INFO' | 'WARN' | 'ERROR', message: string, data?: Record<string, unknown>) => void,
-): Promise<Array<{ id: string; name: string; url: string; accessToken: string }>> {
+): Promise<Array<{ id: string; name: string; url: string; accessToken?: string }>> {
   const enabledConnectors = storage.getEnabledConnectors();
-  const result: Array<{ id: string; name: string; url: string; accessToken: string }> = [];
+  const result: Array<{ id: string; name: string; url: string; accessToken?: string }> = [];
 
   for (const connector of enabledConnectors) {
     if (connector.status !== 'connected') {
@@ -266,6 +266,15 @@ async function resolveConnectors(
 
     let tokens = storage.getConnectorTokens(connector.id);
     if (!tokens?.accessToken) {
+      if (!connector.oauthMetadata && !connector.clientRegistration) {
+        result.push({
+          id: connector.id,
+          name: connector.name,
+          url: connector.url,
+        });
+        continue;
+      }
+
       log('WARN', `[resolveTaskConfig] Missing access token for ${connector.name}`);
       storage.setConnectorStatus(connector.id, 'error');
       continue;


### PR DESCRIPTION
## Summary
- Treat OAuth metadata 404 for custom MCP connectors as a no-auth server path, mark the connector connected, clear stale tokens, and skip opening an OAuth browser flow.
- Allow connected custom MCP connectors without access tokens to be written to OpenCode config without Authorization headers.
- Add desktop IPC and daemon config regression tests for unauthenticated MCP connectors.

Fixes #975

## Testing
- pnpm -F @accomplish/web test:unit
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm -F @accomplish/daemon exec vitest run __tests__/unit/task-config-builder.unit.test.ts --config vitest.config.ts
- pnpm -F @accomplish/desktop exec vitest run __tests__/unit/main/ipc/connector-handlers.unit.test.ts --config vitest.unit.config.ts
- pnpm -F @accomplish_ai/agent-core test (ran with proxy env vars unset; 717 passed, 1 skipped due better-sqlite3 ABI warning)

Note: local pre-push hook also passed typecheck, ESLint, format check, build, web unit, desktop unit, and agent-core tests.