### PR TITLE
fix(lmstudio): discover models from native API

### DIFF
--- a/packages/agent-core/src/providers/lmstudio-models.ts
+++ b/packages/agent-core/src/providers/lmstudio-models.ts
@@ -12,12 +12,25 @@ const log = createConsoleLogger({ prefix: 'LMStudio' });
 /** Default timeout for LM Studio API requests in milliseconds */
 export const LMSTUDIO_REQUEST_TIMEOUT_MS = 15000;
 
-/** Response type from LM Studio /v1/models endpoint */
-interface LMStudioModelsResponse {
+interface RawLMStudioModel {
+  id: string;
+  displayName?: string;
+}
+
+/** Response type from the OpenAI-compatible LM Studio endpoint. */
+interface LMStudioOpenAIModelsResponse {
   data?: Array<{
-    id: string;
-    object: string;
-    owned_by?: string;
+    id?: string;
+  }>;
+}
+
+/** Response type from LM Studio's native v1 endpoint. */
+interface LMStudioNativeModelsResponse {
+  models?: Array<{
+    type?: string;
+    key?: string;
+    id?: string;
+    display_name?: string;
   }>;
 }
 
@@ -53,32 +66,96 @@ export function formatModelDisplayName(modelId: string): string {
   return modelId.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/**
- * Fetch raw model list from LM Studio /v1/models endpoint and enrich with tool support.
- * Shared by both testLMStudioConnection and fetchLMStudioModels.
- */
-export async function fetchAndEnrichModels(
-  baseUrl: string,
-  timeoutMs: number,
-): Promise<LMStudioConnectionResult> {
-  const response = await fetchWithTimeout(`${baseUrl}/v1/models`, { method: 'GET' }, timeoutMs);
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, '').replace(/\/(?:api\/)?v1$/i, '');
+}
+
+function parseModelResponse(data: unknown): RawLMStudioModel[] {
+  if (!data || typeof data !== 'object') {
+    return [];
+  }
+
+  const response = data as LMStudioOpenAIModelsResponse & LMStudioNativeModelsResponse;
+  if (Array.isArray(response.data)) {
+    return response.data.flatMap((model) => {
+      if (typeof model.id !== 'string' || model.id.length === 0) {
+        return [];
+      }
+      return [{ id: model.id }];
+    });
+  }
+
+  if (!Array.isArray(response.models)) {
+    return [];
+  }
+
+  return response.models.flatMap((model) => {
+    // Embedding models cannot be used by the chat provider and should not be
+    // sent through the tool-support probe.
+    if (model.type && model.type !== 'llm') {
+      return [];
+    }
+
+    const id = model.key || model.id;
+    if (!id) {
+      return [];
+    }
+    return [{ id, displayName: model.display_name }];
+  });
+}
+
+interface RawModelFetchResult {
+  success: boolean;
+  models: RawLMStudioModel[];
+  error?: string;
+}
+
+async function fetchRawModels(url: string, timeoutMs: number): Promise<RawModelFetchResult> {
+  const response = await fetchWithTimeout(url, { method: 'GET' }, timeoutMs);
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));
     const errorMessage =
       (errorData as { error?: { message?: string } })?.error?.message ||
       `API returned status ${response.status}`;
-    return { success: false, error: errorMessage };
+    return { success: false, models: [], error: errorMessage };
   }
 
-  const data = (await response.json()) as LMStudioModelsResponse;
-  const rawModels = data.data || [];
+  return { success: true, models: parseModelResponse(await response.json()) };
+}
+
+/**
+ * Fetch raw model list from LM Studio and enrich with tool support.
+ *
+ * LM Studio exposes two model-list APIs. Older and OpenAI-compatible servers
+ * use `/v1/models` with a `data` array, while newer servers also expose the
+ * native `/api/v1/models` endpoint with a `models` array. Keep the compatible
+ * endpoint as the primary path and use the native endpoint when it returns no
+ * usable models so both response formats work without requiring a live server
+ * migration.
+ */
+export async function fetchAndEnrichModels(
+  baseUrl: string,
+  timeoutMs: number,
+): Promise<LMStudioConnectionResult> {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const openAIResult = await fetchRawModels(`${normalizedBaseUrl}/v1/models`, timeoutMs);
+  let rawModels = openAIResult.models;
+
+  if (rawModels.length === 0) {
+    const nativeResult = await fetchRawModels(`${normalizedBaseUrl}/api/v1/models`, timeoutMs);
+    if (nativeResult.models.length > 0) {
+      rawModels = nativeResult.models;
+    } else if (!openAIResult.success && !nativeResult.success) {
+      return { success: false, error: openAIResult.error || nativeResult.error };
+    }
+  }
 
   const models: LMStudioModel[] = [];
 
   for (const m of rawModels) {
-    const displayName = formatModelDisplayName(m.id);
-    const toolSupport = await testLMStudioModelToolSupport(baseUrl, m.id);
+    const displayName = m.displayName || formatModelDisplayName(m.id);
+    const toolSupport = await testLMStudioModelToolSupport(normalizedBaseUrl, m.id);
 
     models.push({
       id: m.id,

--- a/packages/agent-core/src/providers/lmstudio-models.ts
+++ b/packages/agent-core/src/providers/lmstudio-models.ts
@@ -28,9 +28,10 @@ interface LMStudioOpenAIModelsResponse {
 interface LMStudioNativeModelsResponse {
   models?: Array<{
     type?: string;
-    key?: string;
-    id?: string;
     display_name?: string;
+    loaded_instances?: Array<{
+      id?: string;
+    }>;
   }>;
 }
 
@@ -96,11 +97,12 @@ function parseModelResponse(data: unknown): RawLMStudioModel[] {
       return [];
     }
 
-    const id = model.key || model.id;
-    if (!id) {
-      return [];
-    }
-    return [{ id, displayName: model.display_name }];
+    return (model.loaded_instances || []).flatMap((instance) => {
+      if (typeof instance.id !== 'string' || instance.id.length === 0) {
+        return [];
+      }
+      return [{ id: instance.id, displayName: model.display_name }];
+    });
   });
 }
 

--- a/packages/agent-core/src/providers/lmstudio.ts
+++ b/packages/agent-core/src/providers/lmstudio.ts
@@ -26,8 +26,8 @@ export interface LMStudioConnectionOptions {
 /**
  * Tests connection to an LM Studio server and fetches available models.
  *
- * Makes a GET request to /v1/models to verify connectivity and retrieve
- * the list of loaded models. For each model, tests tool support capability.
+ * Queries LM Studio's model-list APIs to verify connectivity and retrieve
+ * available models. For each model, tests tool support capability.
  *
  * @param options - Connection test options
  * @returns Connection result with models if successful

--- a/packages/agent-core/tests/unit/providers/lmstudio-models.test.ts
+++ b/packages/agent-core/tests/unit/providers/lmstudio-models.test.ts
@@ -54,7 +54,7 @@ describe('fetchAndEnrichModels', () => {
     expect(mockedToolSupport).toHaveBeenCalledWith('http://localhost:1234', 'qwen/qwen3-8b');
   });
 
-  it('falls back to the native endpoint when the compatible endpoint is empty', async () => {
+  it('falls back to loaded native instances when the compatible endpoint is empty', async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(response({ data: [] }))
       .mockResolvedValueOnce(
@@ -64,7 +64,13 @@ describe('fetchAndEnrichModels', () => {
               type: 'llm',
               key: 'qwen/qwen3-8b',
               display_name: 'Qwen 3 8B',
-              loaded_instances: [{ id: 'qwen/qwen3-8b' }],
+              loaded_instances: [{ id: 'qwen-custom-instance' }],
+            },
+            {
+              type: 'llm',
+              key: 'mistral/mistral-7b',
+              display_name: 'Mistral 7B',
+              loaded_instances: [],
             },
             {
               type: 'embedding',
@@ -81,7 +87,7 @@ describe('fetchAndEnrichModels', () => {
       success: true,
       models: [
         {
-          id: 'qwen/qwen3-8b',
+          id: 'qwen-custom-instance',
           name: 'Qwen 3 8B',
           toolSupport: 'supported',
         },
@@ -92,7 +98,10 @@ describe('fetchAndEnrichModels', () => {
       'http://localhost:1234/api/v1/models',
       expect.objectContaining({ method: 'GET' }),
     );
-    expect(mockedToolSupport).toHaveBeenCalledTimes(1);
+    expect(mockedToolSupport).toHaveBeenCalledWith(
+      'http://localhost:1234',
+      'qwen-custom-instance',
+    );
   });
 
   it('returns the original endpoint error when both discovery endpoints fail', async () => {

--- a/packages/agent-core/tests/unit/providers/lmstudio-models.test.ts
+++ b/packages/agent-core/tests/unit/providers/lmstudio-models.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchAndEnrichModels } from '../../../src/providers/lmstudio-models.js';
+
+vi.mock('../../../src/providers/tool-support-testing.js', () => ({
+  testLMStudioModelToolSupport: vi.fn(),
+}));
+
+import { testLMStudioModelToolSupport } from '../../../src/providers/tool-support-testing.js';
+
+const mockedToolSupport = vi.mocked(testLMStudioModelToolSupport);
+
+function response(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe('fetchAndEnrichModels', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    mockedToolSupport.mockReset();
+    mockedToolSupport.mockResolvedValue('supported');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('discovers models from the OpenAI-compatible endpoint', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      response({ data: [{ id: 'qwen/qwen3-8b' }] }),
+    );
+
+    const result = await fetchAndEnrichModels('http://localhost:1234/', 1000);
+
+    expect(result).toEqual({
+      success: true,
+      models: [
+        {
+          id: 'qwen/qwen3-8b',
+          name: 'Qwen/Qwen3 8b',
+          toolSupport: 'supported',
+        },
+      ],
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:1234/v1/models',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(mockedToolSupport).toHaveBeenCalledWith('http://localhost:1234', 'qwen/qwen3-8b');
+  });
+
+  it('falls back to the native endpoint when the compatible endpoint is empty', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(response({ data: [] }))
+      .mockResolvedValueOnce(
+        response({
+          models: [
+            {
+              type: 'llm',
+              key: 'qwen/qwen3-8b',
+              display_name: 'Qwen 3 8B',
+              loaded_instances: [{ id: 'qwen/qwen3-8b' }],
+            },
+            {
+              type: 'embedding',
+              key: 'nomic-embed-text',
+              display_name: 'Nomic Embed Text',
+            },
+          ],
+        }),
+      );
+
+    const result = await fetchAndEnrichModels('http://localhost:1234', 1000);
+
+    expect(result).toEqual({
+      success: true,
+      models: [
+        {
+          id: 'qwen/qwen3-8b',
+          name: 'Qwen 3 8B',
+          toolSupport: 'supported',
+        },
+      ],
+    });
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:1234/api/v1/models',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(mockedToolSupport).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the original endpoint error when both discovery endpoints fail', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        response({ error: { message: 'OpenAI endpoint unavailable' } }, false, 404),
+      )
+      .mockResolvedValueOnce(
+        response({ error: { message: 'Native endpoint unavailable' } }, false, 404),
+      );
+
+    const result = await fetchAndEnrichModels('http://localhost:1234', 1000);
+
+    expect(result).toEqual({ success: false, error: 'OpenAI endpoint unavailable' });
+    expect(mockedToolSupport).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Fixes LM Studio model discovery when the OpenAI-compatible `/v1/models` endpoint returns no models by falling back to the native `/api/v1/models` endpoint. Native results are limited to loaded LLM instances and use each instance ID, so unloaded/downloaded models and embedding models are not selectable.

## Type of Change

- [x] `fix`: Bug fix

## Checklist

- [x] PR title follows conventional commit format
- [ ] Changes have been tested locally
- [x] Any new dependencies are justified

## Testing

- Added unit coverage for OpenAI-compatible discovery, native fallback, unloaded-model exclusion, custom loaded-instance IDs, and endpoint failures.
- Ran syntax checks, `git diff --check`, and an isolated mocked runtime simulation.
- Full `pnpm` test/typecheck commands were not run because this environment could not complete dependency installation.

## Related Issues

Closes #979